### PR TITLE
feature/newsletter

### DIFF
--- a/src/components/Markdown.jsx
+++ b/src/components/Markdown.jsx
@@ -44,14 +44,13 @@ export const Author = ({ name }: { name: string }) => (
 );
 
 export type ImageProps = {|
-  src: string,
   align: string,
   caption: string,
   size: string,
   img: Object
 |};
 
-export const Image = ({ src, align, caption, size, img, ...props }: ImageProps) => (
+export const Image = ({ align, caption, size, img, ...props }: ImageProps) => (
   <figure
     className={align ? `mx-auto float-md-${align} size-md-small m-6` : 'mx-auto my-6'}
     style={size ? { width: `${size}px` } : {}}

--- a/src/components/NewsletterForm.jsx
+++ b/src/components/NewsletterForm.jsx
@@ -4,6 +4,8 @@ import * as React from 'react';
 import { Trans } from '@lingui/react';
 import 'isomorphic-fetch';
 
+import { trackSignup } from '../layouts/utils';
+
 export default class extends React.Component<
   Props,
   {
@@ -19,7 +21,9 @@ export default class extends React.Component<
   };
   handleSubmit = (e: any) => {
     const valid = this.re.test(this.state.email);
-    if (!valid) {
+    if (valid) {
+      trackSignup('newsletter');
+    } else {
       e.preventDefault();
       this.setState({ invalid: true });
     }

--- a/src/components/NewsletterForm.jsx
+++ b/src/components/NewsletterForm.jsx
@@ -47,7 +47,7 @@ export default class extends React.Component<
               type="submit"
               name="subscribe"
               id="mc-embedded-subscribe"
-              className="btn btn-primary btn-round btn-xl"
+              className="btn btn-primary btn-round btn-xl ml-2"
             >
               <Trans>Subscribe</Trans>
             </button>

--- a/src/components/Privacy.jsx
+++ b/src/components/Privacy.jsx
@@ -26,6 +26,6 @@ export const PrivacyElement = ({
 );
 PrivacyElement.defaultProps = { body: '', size: '12' };
 
-export const PrivacyRow = ({ children }: { children: React.Element<any> }) => (
+export const PrivacyRow = ({ children }: { children: Array<React.Element<any>> }) => (
   <div className="row gap-y my-4">{children}</div>
 );

--- a/src/components/Privacy.jsx
+++ b/src/components/Privacy.jsx
@@ -26,6 +26,6 @@ export const PrivacyElement = ({
 );
 PrivacyElement.defaultProps = { body: '', size: '12' };
 
-export const PrivacyRow = ({ children }: { children: Array<React.Element<any>> }) => (
+export const PrivacyRow = ({ children }: { children: Array<React.Node> }) => (
   <div className="row gap-y my-4">{children}</div>
 );

--- a/src/components/SignupForm.jsx
+++ b/src/components/SignupForm.jsx
@@ -29,7 +29,7 @@ export default class extends React.Component<
     return (
       <>
         <form
-          action="https://gmail.us3.list-manage.com/subscribe/post?u=9270e3d8bb9a6ef73633717af&amp;id=1c0ab18e1a"
+          action="https://ledgy.us16.list-manage.com/subscribe/post?u=d6181c123b4d20b2104c4652f&amp;id=c9cfbb11a6"
           method="post"
           className="input-round py-5"
           onSubmit={this.handleSubmit}

--- a/src/components/SignupForm.jsx
+++ b/src/components/SignupForm.jsx
@@ -3,101 +3,61 @@
 import * as React from 'react';
 import { Trans } from '@lingui/react';
 import 'isomorphic-fetch';
-import { FontAwesomeIcon } from '@fortawesome/react-fontawesome';
-import { faSpinner } from '@fortawesome/free-solid-svg-icons';
-
-import { appUrl } from '../layouts/utils';
-
-const Submit = ({ className, loading }: { className?: string, loading: boolean }) => (
-  <button
-    type="submit"
-    disabled={loading}
-    className={`btn btn-primary btn-round btn-xl ${className || ''}`}
-  >
-    {loading ? (
-      <Trans>
-        <FontAwesomeIcon icon={faSpinner} spin aria-hidden="true" /> Signing up…
-      </Trans>
-    ) : (
-      <Trans>Get Started</Trans>
-    )}
-  </button>
-);
-Submit.defaultProps = { className: '' };
 
 export default class extends React.Component<
   Props,
   {
     email: string,
-    invalid: boolean,
-    loading: boolean
+    invalid: boolean
   }
 > {
-  state = { email: '', invalid: false, loading: false };
+  state = { email: '', invalid: false };
   re = /^(([^<>()\[\]\\.,;:\s@"]+(\.[^<>()\[\]\\.,;:\s@"]+)*)|(".+"))@((\[[0-9]{1,3}\.[0-9]{1,3}\.[0-9]{1,3}\.[0-9]{1,3}\])|(([a-zA-Z\-0-9]+\.)+[a-zA-Z]{2,}))$/; // eslint-disable-line no-useless-escape
   handleChange = (e: SyntheticInputEvent<HTMLInputElement>) => {
     e.preventDefault();
     this.setState({ email: e.target.value, invalid: false });
   };
   handleSubmit = (e: any) => {
-    e.preventDefault();
-    if (this.state.loading) return;
     const valid = this.re.test(this.state.email);
     if (!valid) {
+      e.preventDefault();
       this.setState({ invalid: true });
-      return;
     }
-    this.setState({ loading: true });
-    const email = encodeURIComponent(this.state.email);
-
-    window.ga('send', 'event', 'signup', 'enterEmail');
-    fetch('/', {
-      method: 'POST',
-      headers: { 'Content-Type': 'application/x-www-form-urlencoded' },
-      body: `form-name=signup&email=${email}&referrer=${encodeURIComponent(
-        document.referrer
-      )}&href=${encodeURIComponent(`${window.location.href}`)}`
-    }).then(() => {
-      window.location.href = `${appUrl}/signup?email=${email}&_ga=${window.clientId || ''}`;
-    });
   };
   render = () => {
     const { i18n } = this.props;
     return (
-      <form
-        name="signup"
-        className="input-round py-5"
-        onSubmit={this.handleSubmit}
-        data-netlify="true"
-        data-netlify-honeypot="bot-field"
-      >
-        <div className="form-group input-group bg-white gap-y p-2 mb-0">
-          <input
-            type="text"
-            name="email"
-            aria-label="E-mail"
-            className="form-control form-control"
-            value={this.state.email}
-            onChange={this.handleChange}
-            placeholder={i18n.t`Enter your email…`}
-            disabled={this.state.loading}
-          />
-          <div className="input-group-append d-none d-sm-block">
-            <Submit {...this.state} />
+      <>
+        <form
+          action="https://gmail.us3.list-manage.com/subscribe/post?u=9270e3d8bb9a6ef73633717af&amp;id=1c0ab18e1a"
+          method="post"
+          className="input-round py-5"
+          onSubmit={this.handleSubmit}
+          noValidate
+        >
+          <div className="form-group input-group bg-white gap-y p-2 mb-0">
+            <input
+              type="email"
+              name="EMAIL"
+              className="form-control"
+              placeholder={i18n.t`Enter your email…`}
+              onChange={this.handleChange}
+            />
+            <button
+              type="submit"
+              value="Subscribe"
+              name="subscribe"
+              id="mc-embedded-subscribe"
+              className="btn btn-primary btn-round btn-xl"
+            >
+              <Trans>Subscribe</Trans>
+            </button>
           </div>
-        </div>
-        <Submit {...this.state} className="d-sm-none btn-block py-3 mt-2 fs-17" />
-        <div className="d-none">
-          <div>
-            Don’t fill this out if you’re human: <input name="bot-field" />
-          </div>
-          <input name="referrer" />
-          <input name="href" />
-        </div>
-        <small className={`text-danger ${this.state.invalid ? '' : 'invisible'}`}>
-          <Trans>Oops. This email address is invalid.</Trans>
-        </small>
-      </form>
+          <small className={`text-danger ${this.state.invalid ? '' : 'invisible'}`}>
+            <Trans>Oops. This email address is invalid.</Trans>
+          </small>
+        </form>
+      </>
     );
   };
 }

--- a/src/components/SignupForm.jsx
+++ b/src/components/SignupForm.jsx
@@ -45,7 +45,6 @@ export default class extends React.Component<
             />
             <button
               type="submit"
-              value="Subscribe"
               name="subscribe"
               id="mc-embedded-subscribe"
               className="btn btn-primary btn-round btn-xl"

--- a/src/layouts/index.jsx
+++ b/src/layouts/index.jsx
@@ -93,7 +93,7 @@ const Footer = (props: LayoutProps) => (
           </h2>
 
           <p className="text-muted">
-            <Trans>And stay up-to-date with everything your start-up needs</Trans>
+            <Trans>and stay up-to-date with everything your start-up needs</Trans>
           </p>
 
           <SignupForm {...props} />

--- a/src/layouts/index.jsx
+++ b/src/layouts/index.jsx
@@ -70,7 +70,11 @@ const Nav = (props: LayoutProps) => (
       </section>
 
       <div className="navbar-right">
-        <a className="btn btn-round btn-outline-light ml-lg-4 mr-2" href={`${appUrl}/login`}>
+        <a
+          className="btn btn-round btn-outline-light ml-lg-4 mr-2"
+          href={`${appUrl}/login`}
+          onClick={() => trackSignup('login')}
+        >
           <Trans>Log In</Trans>
         </a>
         <a

--- a/src/layouts/index.jsx
+++ b/src/layouts/index.jsx
@@ -70,14 +70,12 @@ const Nav = (props: LayoutProps) => (
       </section>
 
       <div className="navbar-right">
-        <a className="btn btn-round btn-outline-light ml-lg-4 mr-2" href={appUrl}>
+        <a className="btn btn-round btn-outline-light ml-lg-4 mr-2" href={`${appUrl}/login`}>
           <Trans>Log In</Trans>
         </a>
-        {showSubscribe(props.location.pathname) && (
-          <a className="btn btn-round btn-light ml-lg-0 mr-2" href="#subscribe">
-            <Trans>Subscribe</Trans>
-          </a>
-        )}
+        <a className="btn btn-round btn-light ml-lg-0 mr-2" href={`${appUrl}/signup`}>
+          <Trans>Sign up</Trans>
+        </a>
       </div>
     </div>
   </nav>
@@ -86,14 +84,14 @@ const Nav = (props: LayoutProps) => (
 const Footer = (props: LayoutProps) => (
   <div>
     {showSubscribe(props.location.pathname) && (
-      <section className="section bg-pale-secondary" id="subscribe">
+      <section className="section bg-pale-secondary">
         <div className="container text-center signup py-md-7">
           <h2>
-            <Trans>Subscribe to our newsletter</Trans>
+            <Trans>Subscribe to the newsletter</Trans>
           </h2>
 
           <p className="text-muted">
-            <Trans>and stay up-to-date with everything your start-up needs</Trans>
+            <Trans>to get monthly updates about new features and start-up resources</Trans>
           </p>
 
           <SignupForm {...props} />

--- a/src/layouts/index.jsx
+++ b/src/layouts/index.jsx
@@ -19,7 +19,7 @@ import 'prism-themes/themes/prism-ghcolors.css';
 
 import { Title, name, appUrl, loadScript, targetBlank, animateTablet, trackSignup } from './utils';
 import { catalogs, langFromPath, langPrefix, getLocale, deprefix } from '../i18n-config';
-import SignupForm from '../components/SignupForm';
+import NewsletterForm from '../components/NewsletterForm';
 
 import '../assets/scss/page.scss';
 
@@ -89,7 +89,7 @@ const Footer = (props: LayoutProps) => (
   <div>
     {showSubscribe(props.location.pathname) && (
       <section className="section bg-pale-secondary">
-        <div className="container text-center signup py-md-7">
+        <div className="container text-center newsletter py-md-7">
           <h2>
             <Trans>Subscribe to the newsletter</Trans>
           </h2>
@@ -98,7 +98,7 @@ const Footer = (props: LayoutProps) => (
             <Trans>for monthly updates on new features and start-up resources</Trans>
           </p>
 
-          <SignupForm {...props} />
+          <NewsletterForm {...props} />
         </div>
       </section>
     )}

--- a/src/layouts/index.jsx
+++ b/src/layouts/index.jsx
@@ -72,8 +72,8 @@ const Nav = (props: LayoutProps) => (
         <a className="btn btn-round btn-outline-light ml-lg-4 mr-2" href={appUrl}>
           <Trans>Log In</Trans>
         </a>
-        <a className="btn btn-round btn-light ml-lg-0 mr-2" href="#try">
-          <Trans>Sign Up</Trans>
+        <a className="btn btn-round btn-light ml-lg-0 mr-2" href="#subscribe">
+          <Trans>Subscribe</Trans>
         </a>
       </div>
     </div>
@@ -83,14 +83,14 @@ const Nav = (props: LayoutProps) => (
 const Footer = (props: LayoutProps) => (
   <div>
     {hasFooter(props.location.pathname) && (
-      <section className="section bg-pale-secondary" id="try">
+      <section className="section bg-pale-secondary" id="subscribe">
         <div className="container text-center signup py-md-7">
           <h2>
-            <Trans>Try Ledgy now for free</Trans>
+            <Trans>Subscribe to our newsletter</Trans>
           </h2>
 
           <p className="text-muted">
-            <Trans>No credit card required</Trans>
+            <Trans>And stay up-to-date with everything your start-up needs</Trans>
           </p>
 
           <SignupForm {...props} />

--- a/src/layouts/index.jsx
+++ b/src/layouts/index.jsx
@@ -17,7 +17,7 @@ import 'typeface-work-sans'; // eslint-disable-line import/extensions
 import 'katex/dist/katex.min.css';
 import 'prism-themes/themes/prism-ghcolors.css';
 
-import { Title, name, appUrl, loadScript, targetBlank, animateTablet } from './utils';
+import { Title, name, appUrl, loadScript, targetBlank, animateTablet, trackSignup } from './utils';
 import { catalogs, langFromPath, langPrefix, getLocale, deprefix } from '../i18n-config';
 import SignupForm from '../components/SignupForm';
 
@@ -73,7 +73,11 @@ const Nav = (props: LayoutProps) => (
         <a className="btn btn-round btn-outline-light ml-lg-4 mr-2" href={`${appUrl}/login`}>
           <Trans>Log In</Trans>
         </a>
-        <a className="btn btn-round btn-light ml-lg-0 mr-2" href={`${appUrl}/signup`}>
+        <a
+          className="btn btn-round btn-light ml-lg-0 mr-2"
+          href={`${appUrl}/signup`}
+          onClick={trackSignup}
+        >
           <Trans>Sign up</Trans>
         </a>
       </div>

--- a/src/layouts/index.jsx
+++ b/src/layouts/index.jsx
@@ -91,7 +91,7 @@ const Footer = (props: LayoutProps) => (
           </h2>
 
           <p className="text-muted">
-            <Trans>to get monthly updates about new features and start-up resources</Trans>
+            <Trans>for monthly updates on new features and start-up resources</Trans>
           </p>
 
           <SignupForm {...props} />

--- a/src/layouts/index.jsx
+++ b/src/layouts/index.jsx
@@ -26,7 +26,8 @@ import '../assets/scss/page.scss';
 import logoDefault from '../img/logo_black.png';
 import logoInverse from '../img/logo_white.png';
 
-const hasFooter = (pathname: string) => !pathname.match(/contact/);
+const showSubscribe = (pathname: string) =>
+  !pathname.match(/contact/) && !pathname.match(/subscribed/);
 
 type LayoutProps = {
   ...$Exact<Props>,
@@ -72,9 +73,11 @@ const Nav = (props: LayoutProps) => (
         <a className="btn btn-round btn-outline-light ml-lg-4 mr-2" href={appUrl}>
           <Trans>Log In</Trans>
         </a>
-        <a className="btn btn-round btn-light ml-lg-0 mr-2" href="#subscribe">
-          <Trans>Subscribe</Trans>
-        </a>
+        {showSubscribe(props.location.pathname) && (
+          <a className="btn btn-round btn-light ml-lg-0 mr-2" href="#subscribe">
+            <Trans>Subscribe</Trans>
+          </a>
+        )}
       </div>
     </div>
   </nav>
@@ -82,7 +85,7 @@ const Nav = (props: LayoutProps) => (
 
 const Footer = (props: LayoutProps) => (
   <div>
-    {hasFooter(props.location.pathname) && (
+    {showSubscribe(props.location.pathname) && (
       <section className="section bg-pale-secondary" id="subscribe">
         <div className="container text-center signup py-md-7">
           <h2>

--- a/src/layouts/style.scss
+++ b/src/layouts/style.scss
@@ -112,6 +112,7 @@ h1 {
   margin-bottom: 0;
 }
 .pricing-3 {
+  max-width: 380px;
   @include media-breakpoint-up(lg) {
     height: 1210px; 
   }

--- a/src/layouts/style.scss
+++ b/src/layouts/style.scss
@@ -104,7 +104,7 @@ h1 {
     padding: 10px 15px;
   }
 }
-.signup {
+.newsletter {
   max-width: 600px;
 }
 

--- a/src/layouts/style.scss
+++ b/src/layouts/style.scss
@@ -112,6 +112,9 @@ h1 {
   margin-bottom: 0;
 }
 .pricing-3 {
+  @include media-breakpoint-up(lg) {
+    height: 840px; 
+  }
   h6 {
     height: 2rem;
   }

--- a/src/layouts/style.scss
+++ b/src/layouts/style.scss
@@ -113,18 +113,29 @@ h1 {
 }
 .pricing-3 {
   @include media-breakpoint-up(lg) {
+    height: 1210px; 
+  }
+  @include media-breakpoint-up(xl) {
     height: 840px; 
-  }
-  h6 {
-    height: 2rem;
-  }
-  h4 {
-    height: 4.5rem;
   }
   li {
     position: relative;
-    height: 3em;
     line-height: 1.2;
+    height: 3em;
+    @include media-breakpoint-up(lg) {
+      height: 5em;
+    }
+    @include media-breakpoint-up(xl) {
+      height: 3em;
+    }
+  }
+  .pricing-top {
+    @include media-breakpoint-up(lg) {
+      height: 150px; 
+    }
+    @include media-breakpoint-up(xl) {
+      height: unset; 
+    }
   }
 }
 

--- a/src/layouts/utils.jsx
+++ b/src/layouts/utils.jsx
@@ -21,8 +21,8 @@ export const loadScript = (path: string): Promise<*> =>
     return (document.body && document.body.appendChild(script)) || reject();
   });
 
-export const trackSignup = () => {
-  if (window.ga) window.ga('send', 'event', 'signup', 'enterEmail');
+export const trackSignup = (type: string = 'clickSignup') => {
+  if (window.ga) window.ga('send', 'event', 'signup', type);
 };
 
 export const Title = (props: {

--- a/src/layouts/utils.jsx
+++ b/src/layouts/utils.jsx
@@ -21,6 +21,10 @@ export const loadScript = (path: string): Promise<*> =>
     return (document.body && document.body.appendChild(script)) || reject();
   });
 
+export const trackSignup = () => {
+  if (window.ga) window.ga('send', 'event', 'signup', 'enterEmail');
+};
+
 export const Title = (props: {
   title: string,
   section?: string,

--- a/src/locale/de/messages.po
+++ b/src/locale/de/messages.po
@@ -6,26 +6,26 @@ msgstr ""
 "Content-Transfer-Encoding: 8bit\n"
 "Plural-Forms: nplurals=2; plural=(n != 1);\n"
 "POT-Creation-Date: 2018-09-12T18:40:54.619Z\n"
-"PO-Revision-Date: 2019-07-04 11:36+0200\n"
+"PO-Revision-Date: 2019-07-05 12:06+0200\n"
 "Language: de\n"
 "Report-Msgid-Bugs-To: \n"
 "Last-Translator: \n"
 "Language-Team: \n"
-"X-Generator: Poedit 2.2.3\n"
+"X-Generator: Poedit 2.2.1\n"
 
-#: src/pages/pricing.jsx:15
+#: src/pages/pricing.jsx:19
 msgid "1 round, 1 scenario"
 msgstr "1 Runde, 1 Szenario"
 
-#: src/pages/pricing.jsx:16
+#: src/pages/pricing.jsx:20
 msgid "2 admins, stakeholder access"
 msgstr "2 Admins, Investor-Zugriff"
 
-#: src/pages/pricing.jsx:83
+#: src/pages/pricing.jsx:87
 msgid "30-day trial"
-msgstr ""
+msgstr "30 Tage testen"
 
-#: src/pages/pricing.jsx:28
+#: src/pages/pricing.jsx:32
 msgid "4 admins, view-only access"
 msgstr "4 Admins, Nur-Lese-Zugriff"
 
@@ -45,19 +45,16 @@ msgstr "<0>Ansicht</0> Lesezugriff auf alle Informationen für Due-Diligence"
 msgid "A certificate of each document is automatically stored on the bitcoin blockchain when uploading"
 msgstr "Für jedes Dokument wird beim Hochladen automatisch ein Zertifikat auf der Bitcoin-Blockchain gespeichert"
 
-#: src/pages/pricing.jsx:161
+#: src/pages/pricing.jsx:165
 msgid "A stakeholder is any holder of shares, (phantom) options, warrants, or convertibles.<0/>It does not include the company treasury or incentive pools."
 msgstr "Ein Stakeholder ist Halter von Anteilen, Optionen, Phantom-Anteilen, Warrants oder Wandeldarlehen.<0/>Die Firma selbst oder Beteiligungspools werden nicht eingerechnet."
 
-#: src/layouts/index.jsx:115
-#: src/pages/about-us.jsx:17
+#: src/layouts/index.jsx:115 src/pages/about-us.jsx:17
 #: src/pages/about-us.jsx:25
 msgid "About us"
 msgstr "Über uns"
 
-#: src/pages/pricing.jsx:16
-#: src/pages/pricing.jsx:28
-#: src/pages/pricing.jsx:39
+#: src/pages/pricing.jsx:20 src/pages/pricing.jsx:32 src/pages/pricing.jsx:43
 msgid "Access rights"
 msgstr "Zugriffsrechte"
 
@@ -89,12 +86,11 @@ msgstr "Vesting hinzufügen"
 msgid "Add vesting or inverse vesting to any transaction"
 msgstr "Hinzufügen von Vesting oder inversem Vesting zu jeder Transaktion"
 
-#: src/pages/features/modeling.jsx:53
-#: src/pages/features/modeling.jsx:111
+#: src/pages/features/modeling.jsx:53 src/pages/features/modeling.jsx:111
 msgid "Adjust your simulations"
 msgstr "Flexible Einstellungen"
 
-#: src/pages/pricing.jsx:36
+#: src/pages/pricing.jsx:40
 msgid "All Premium features"
 msgstr "Alle Premium-Features"
 
@@ -102,12 +98,11 @@ msgstr "Alle Premium-Features"
 msgid "All data is stored at an <0>independent provider</0> in France"
 msgstr "Alle Daten werden bei einem <0>unabhängigen Anbieter</0> in Frankreich gespeichert"
 
-#: src/pages/pricing.jsx:25
+#: src/pages/pricing.jsx:29
 msgid "All standard features"
-msgstr ""
+msgstr "Alle Standard-Features"
 
-#: src/components/Feature.jsx:89
-#: src/pages/features.jsx:23
+#: src/components/Feature.jsx:89 src/pages/features.jsx:23
 msgid "All you need in one place"
 msgstr "Alles an einem Ort"
 
@@ -123,8 +118,7 @@ msgstr "Ein stets aktuelles Portfolio, von deinen Start-ups gepflegt"
 msgid "Analyze it by stakeholder, share class, stakeholder group and view it with all, outstanding or diluted shares"
 msgstr "Analysiere nach Stakeholder, Aktienklasse, Stakeholdergruppe, nur mit ausstehenden Anteilen oder verwässert"
 
-#: src/pages/features/esop.jsx:92
-#: src/pages/pricing.jsx:26
+#: src/pages/features/esop.jsx:92 src/pages/pricing.jsx:30
 msgid "Any vesting schedule"
 msgstr "Beliebiges Vesting"
 
@@ -148,8 +142,7 @@ msgstr "Wir bei Ledgy nehmen deine Sicherheit ernst. Sichere Passwörter, solide
 msgid "Attach doc to transaction"
 msgstr "Dokument an Transaktion anhängen"
 
-#: src/pages/features/captable.jsx:53
-#: src/pages/features/captable.jsx:136
+#: src/pages/features/captable.jsx:53 src/pages/features/captable.jsx:136
 msgid "Attach documents"
 msgstr "Dokumente anhängen"
 
@@ -201,14 +194,12 @@ msgstr "Blockchain-Zertifizierung"
 msgid "Blockchain notary"
 msgstr "Blockchain-Notar"
 
-#: src/layouts/index.jsx:65
-#: src/layouts/index.jsx:118
-#: src/layouts/index.jsx:158
+#: src/layouts/index.jsx:65 src/layouts/index.jsx:118 src/layouts/index.jsx:158
 #: src/pages/blog.jsx:61
 msgid "Blog"
 msgstr "Blog"
 
-#: src/pages/pricing.jsx:32
+#: src/pages/pricing.jsx:36
 msgid "Breakpoint & exit analyses"
 msgstr "Breakpoint & Exit-Analyse"
 
@@ -240,8 +231,7 @@ msgstr "Berechnet die Wasserfallanalyse der Liquidationspräferenzen über alle 
 msgid "Cap Table"
 msgstr "Cap Table"
 
-#: src/components/Feature.jsx:99
-#: src/pages/features.jsx:58
+#: src/components/Feature.jsx:99 src/pages/features.jsx:58
 msgid "Cap Table Management"
 msgstr "Cap Table Management"
 
@@ -249,7 +239,7 @@ msgstr "Cap Table Management"
 msgid "Cap table during round modeling"
 msgstr "Cap Table während der Finanzierungsrundensimulation"
 
-#: src/pages/pricing.jsx:13
+#: src/pages/pricing.jsx:17
 msgid "Cap table management"
 msgstr "Cap Table-Verwaltung"
 
@@ -265,18 +255,20 @@ msgstr "Wähle aus, ob nur Pools oder die Detailansicht mit den ausgegebenen Gra
 msgid "Coding since high school, Timo got an award for the best master thesis in computer science and worked one year as a computer engineer in robotics"
 msgstr "Timo programmiert seit seiner Schulzeit, wurde für die beste Masterarbeit in Computer Science ausgezeichnet und hat ein Jahr als Computer Engineer in der Robotik gearbeitet"
 
-#: src/components/Feature.jsx:101
-#: src/pages/features/collaboration.jsx:20
+#: src/components/Feature.jsx:101 src/pages/features/collaboration.jsx:20
 #: src/pages/features.jsx:104
 msgid "Collaboration & Due Diligence"
 msgstr "Zusammenarbeit & Due Diligence"
+
+#: src/pages/pricing.jsx:12
+msgid "Coming soon"
+msgstr "Bald verfügbar"
 
 #: src/layouts/index.jsx:110
 msgid "Company"
 msgstr "Unternehmen"
 
-#: src/pages/features/modeling.jsx:47
-#: src/pages/features/modeling.jsx:95
+#: src/pages/features/modeling.jsx:47 src/pages/features/modeling.jsx:95
 #: src/pages/features/modeling.jsx:105
 msgid "Compare and share scenarios"
 msgstr "Szenarien vergleichen und teilen"
@@ -289,8 +281,7 @@ msgstr "Vervollständige dein Portfolio"
 msgid "Comprehensive transaction history"
 msgstr "Umfassende Transaktionshistorie"
 
-#: src/pages/contact.jsx:10
-#: src/pages/contact.jsx:74
+#: src/pages/contact.jsx:10 src/pages/contact.jsx:74
 msgid "Contact"
 msgstr "Kontakt"
 
@@ -302,8 +293,7 @@ msgstr "Kontakt & Impressum"
 msgid "Contact data, usage statistics, and technical data"
 msgstr "Kontaktdaten, Nutzungsstatistiken und technische Daten"
 
-#: src/pages/pricing.jsx:152
-#: src/pages/pricing.jsx:154
+#: src/pages/pricing.jsx:156 src/pages/pricing.jsx:158
 msgid "Contact us"
 msgstr "Kontaktiere uns"
 
@@ -313,7 +303,7 @@ msgstr "Content-Security-Policy"
 
 #: src/pages/subscribed.jsx:40
 msgid "Continue exploring"
-msgstr ""
+msgstr "Weiterstöbern"
 
 #: src/pages/features/modeling.jsx:168
 msgid "Convert financing round"
@@ -327,7 +317,7 @@ msgstr "Konvertiere das endgültige Szenario in Transaktionen mit nur zwei Klick
 msgid "Convert to transactions"
 msgstr "In Transaktionen umwandeln"
 
-#: src/pages/pricing.jsx:20
+#: src/pages/pricing.jsx:24
 msgid "Convertibles"
 msgstr "Wandeldarlehen"
 
@@ -363,12 +353,11 @@ msgstr "Datenraum, Audit-Trail und schreibgeschützter Zugriff für Investoren e
 msgid "Digital entrepreneur and investor. Security, crypto & privacy expert"
 msgstr "Digital Entrepreneur und Investor. Security-, Crypto- & Privacy-Experte"
 
-#: src/pages/features/esop.jsx:137
-#: src/pages/features/modeling.jsx:140
+#: src/pages/features/esop.jsx:137 src/pages/features/modeling.jsx:140
 msgid "Diluted cap table"
 msgstr "Verwässerter Cap Table"
 
-#: src/pages/pricing.jsx:169
+#: src/pages/pricing.jsx:173
 msgid "Discover all features"
 msgstr "Entdecke alle Features"
 
@@ -388,17 +377,15 @@ msgstr "Dokumentverknüpfungen"
 msgid "Document management"
 msgstr "Dokumenteverwaltung"
 
-#: src/pages/pricing.jsx:17
-#: src/pages/pricing.jsx:29
-#: src/pages/pricing.jsx:40
+#: src/pages/pricing.jsx:21 src/pages/pricing.jsx:33 src/pages/pricing.jsx:44
 msgid "Document storage"
 msgstr "Dokumentenablage"
 
-#: src/pages/pricing.jsx:43
+#: src/pages/pricing.jsx:47
 msgid "Document workflow <0/>"
-msgstr ""
+msgstr "Dokumenten-Workflows <0/>"
 
-#: src/pages/pricing.jsx:175
+#: src/pages/pricing.jsx:179
 msgid "Does your startup tackle the climate crisis?"
 msgstr "Hilft dein Startup, die Klimakrise zu lösen?"
 
@@ -434,9 +421,9 @@ msgstr "EU-Datenschutz"
 msgid "Edit log"
 msgstr "Bearbeitungsprotokoll"
 
-#: src/pages/pricing.jsx:49
+#: src/pages/pricing.jsx:53
 msgid "Electronic signatures <0/>"
-msgstr ""
+msgstr "Elektronische Signaturen <0/>"
 
 #: src/pages/features/esop.jsx:123
 msgid "Email notification about upcoming vesting event"
@@ -446,8 +433,7 @@ msgstr "E-Mail-Benachrichtigung über bevorstehende Vesting-Ereignisse"
 msgid "Employee Incentives"
 msgstr "Mitarbeiter​​​​beteiligungen"
 
-#: src/components/Feature.jsx:98
-#: src/pages/features/esop.jsx:25
+#: src/components/Feature.jsx:98 src/pages/features/esop.jsx:25
 #: src/pages/features.jsx:33
 msgid "Employee Participation Plans"
 msgstr "Mitarbeiterbeteiligungspläne"
@@ -456,8 +442,7 @@ msgstr "Mitarbeiterbeteiligungspläne"
 msgid "Encrypted connection"
 msgstr "Verschlüsselte Verbindung"
 
-#: src/pages/features/esop.jsx:48
-#: src/pages/features/esop.jsx:109
+#: src/pages/features/esop.jsx:48 src/pages/features/esop.jsx:109
 msgid "Engage your employees"
 msgstr "Motiviere deine Mitarbeiter"
 
@@ -477,8 +462,7 @@ msgstr "Unternehmer, Business Angel, Gründer von Doodle.com"
 msgid "Entrepreneur, technologist, founder of Doodle.com"
 msgstr "Unternehmer, Technologe, Gründer von Doodle.com"
 
-#: src/pages/privacy.jsx:77
-#: src/pages/privacy.jsx:129
+#: src/pages/privacy.jsx:77 src/pages/privacy.jsx:129
 msgid "Equity data"
 msgstr "Aktiendaten"
 
@@ -486,7 +470,7 @@ msgstr "Aktiendaten"
 msgid "Equity data is too important to be accidentally tweaked in a spreadsheet"
 msgstr "Beteiligungsdaten sind zu wichtig, um sie versehentlich in einem Tabellendokument zu verändern"
 
-#: src/pages/pricing.jsx:26
+#: src/pages/pricing.jsx:30
 msgid "Equity plan management"
 msgstr "Beteiligungspläne"
 
@@ -498,8 +482,7 @@ msgstr "Europe’s symbiosis of early-stage VC funds and private investor networ
 msgid "Every company has KPIs, and investors love seeing them in real-time"
 msgstr "Jedes Unternehmen hat KPIs und Investoren lieben es, sie in Echtzeit zu verfolgen"
 
-#: src/pages/features/modeling.jsx:173
-#: src/pages/features/modeling.jsx:186
+#: src/pages/features/modeling.jsx:173 src/pages/features/modeling.jsx:186
 msgid "Exit modeling"
 msgstr "Exit-Modellierung"
 
@@ -507,14 +490,10 @@ msgstr "Exit-Modellierung"
 msgid "FAQ"
 msgstr "FAQ"
 
-#: src/layouts/index.jsx:59
-#: src/layouts/index.jsx:186
-#: src/pages/features/captable.jsx:21
-#: src/pages/features/collaboration.jsx:21
-#: src/pages/features/esop.jsx:16
-#: src/pages/features/investors.jsx:21
-#: src/pages/features/modeling.jsx:21
-#: src/pages/features.jsx:14
+#: src/layouts/index.jsx:59 src/layouts/index.jsx:186
+#: src/pages/features/captable.jsx:21 src/pages/features/collaboration.jsx:21
+#: src/pages/features/esop.jsx:16 src/pages/features/investors.jsx:21
+#: src/pages/features/modeling.jsx:21 src/pages/features.jsx:14
 msgid "Features"
 msgstr "Funktionen"
 
@@ -526,9 +505,7 @@ msgstr "Mit beliebig vielen Anteilsklassen, Treasury Anteilen, gepoolten Investi
 msgid "Finally, I have a reliable overview of all our shares, employee grants, and their legal documents. So much better than the Excel I used before."
 msgstr "Endlich habe ich eine zuverlässige Übersicht über all unsere Aktien, Mitarbeiterdarlehen und die rechtlichen Dokumente dazu. Das ist so viel besser als Excel, das ich früher benutzt habe."
 
-#: src/pages/pricing.jsx:15
-#: src/pages/pricing.jsx:27
-#: src/pages/pricing.jsx:38
+#: src/pages/pricing.jsx:19 src/pages/pricing.jsx:31 src/pages/pricing.jsx:42
 msgid "Financing round modeling"
 msgstr "Modellierung von Runden"
 
@@ -548,9 +525,9 @@ msgstr "Für noch mehr Sicherheit der Nutzerkonten. Übrigens, unsere Implementi
 msgid "Founder of Meisser Economics, Bitcoin Association Switzerland, and Wuala"
 msgstr "Gründer von Meisser Economics, Bitcoin Association Schweiz und Wuala"
 
-#: src/pages/pricing.jsx:138
+#: src/pages/pricing.jsx:142
 msgid "Free"
-msgstr ""
+msgstr "Gratis"
 
 #: src/layouts/index.jsx:226
 msgid "GDPR"
@@ -572,7 +549,7 @@ msgstr "Bekomme Benachrichtigungen zu wichtigen Vesting- und Verfallsdaten und b
 msgid "Get notified two weeks before a cliff or vesting ends or a grant expires to not miss using your participation plan for engaging your employees"
 msgstr "Lasse dich vor dem Ende eines Cliffs, Vestings oder Verfallsdatums benachrichtigen, damit du nicht die Chance verpasst, deine Mitarbeiter mit der Beteiligung zu motivieren"
 
-#: src/pages/pricing.jsx:140
+#: src/pages/pricing.jsx:144
 msgid "Get started"
 msgstr "Los geht’s"
 
@@ -580,8 +557,7 @@ msgstr "Los geht’s"
 msgid "Get started in minutes with the copy-paste spreadsheet importer"
 msgstr "Lege in wenigen Minuten mit dem Copy-Paste-Tool für bestehende Tabellen los"
 
-#: src/pages/features/modeling.jsx:41
-#: src/pages/features/modeling.jsx:76
+#: src/pages/features/modeling.jsx:41 src/pages/features/modeling.jsx:76
 #: src/pages/features/modeling.jsx:88
 msgid "Get the calculations right"
 msgstr "Vermeide kostspielige Fehler"
@@ -600,7 +576,7 @@ msgstr "Erste Schritte"
 
 #: src/pages/subscribed.jsx:43
 msgid "Go to Ledgy app"
-msgstr ""
+msgstr "Zur Ledgy-App"
 
 #: src/pages/features/esop.jsx:80
 msgid "Grant options, phantom options, warrants or add inverse vesting to stock transactions"
@@ -636,8 +612,7 @@ msgid "Holding confirmation"
 msgstr "Besitzbestätigung"
 
 #: src/pages/features/collaboration.jsx:59
-#: src/pages/features/collaboration.jsx:169
-#: src/pages/pricing.jsx:18
+#: src/pages/features/collaboration.jsx:169 src/pages/pricing.jsx:22
 msgid "Holding confirmations"
 msgstr "Besitzbestätigungen"
 
@@ -685,10 +660,8 @@ msgstr "Intuitive, rechtsgültige und fehlerfreie Cap Tables von Anfang an, die 
 msgid "Investor & consultant (Farmy.ch, Flatfox.ch), founder of Students.ch"
 msgstr "Investor & Berater (Farmy.ch, Flatfox.ch), Gründer von Students.ch"
 
-#: src/components/Feature.jsx:102
-#: src/pages/features/investors.jsx:20
-#: src/pages/features/investors.jsx:30
-#: src/pages/features.jsx:126
+#: src/components/Feature.jsx:102 src/pages/features/investors.jsx:20
+#: src/pages/features/investors.jsx:30 src/pages/features.jsx:126
 msgid "Investor Relations & Portfolio"
 msgstr "Investor Relations & Portfolio"
 
@@ -768,7 +741,7 @@ msgstr "Erfahre mehr über Dokumentenverwaltung"
 msgid "Ledgy makes it easy to simulate an investment with a pro-rata distribution"
 msgstr "Ledgy macht es einfach, eine Investition mit einer pro-rata Verteilung zu simulieren"
 
-#: src/pages/pricing.jsx:118
+#: src/pages/pricing.jsx:122
 msgid "Ledgy scales with your needs. Free for startups, powerful for grown-ups."
 msgstr "Ledgy skaliert mit deinen Anforderungen. Kostenlos für Startups, leistungsstark für größere Firmen."
 
@@ -784,7 +757,7 @@ msgstr "Rechtliche Dokumente zu jeder Transaktionen auf einen Blick"
 msgid "Let’s Get In Touch"
 msgstr "Kontaktiere uns"
 
-#: src/pages/pricing.jsx:31
+#: src/pages/pricing.jsx:35
 msgid "Liquidation preferences"
 msgstr "Liquidationspräferenzen"
 
@@ -820,7 +793,7 @@ msgstr "Lerne das Team hinter Ledgy kennen, das sich zum Ziel gesetzt hat, Start
 msgid "Modeling"
 msgstr "Modellierung"
 
-#: src/pages/pricing.jsx:27
+#: src/pages/pricing.jsx:31
 msgid "Multiple rounds, 3 scenarios"
 msgstr "Mehrere Runden, 3 Szenarien"
 
@@ -832,7 +805,7 @@ msgstr "Name, E-Mail, Adresse und alle anderen Angaben, die du machst. Für die 
 msgid "Nobody has any access to the equity data you provide. They are safely stored at a secure data center in France. Your stakeholders have no access and don’t get emails before you explicitly invite them"
 msgstr "Niemand hat Zugang zu den von dir angegebenen Aktiendaten. Sie werden sicher in einem geschützten Rechenzentrum in Frankreich gespeichert. Deine Stakeholder haben keinen Zugriff und erhalten keine E-Mails, bevor du sie nicht explizit einlädst"
 
-#: src/pages/pricing.jsx:30
+#: src/pages/pricing.jsx:34
 msgid "Notifications"
 msgstr "Benachrichtigungen"
 
@@ -868,7 +841,7 @@ msgstr "Passwort-Verschlüsselung"
 msgid "Peer-reviewed code"
 msgstr "Code-Audits"
 
-#: src/pages/pricing.jsx:37
+#: src/pages/pricing.jsx:41
 msgid "Phone & chat, onboarding"
 msgstr "Telefon & Chat, Onboarding"
 
@@ -880,36 +853,30 @@ msgstr "Experimentiere mit gründer- oder investorenfreundlichen Rahmenbedingung
 msgid "Pooled investment"
 msgstr "Gepoolte Investments"
 
-#: src/pages/features/captable.jsx:47
-#: src/pages/features/captable.jsx:117
-#: src/pages/pricing.jsx:19
+#: src/pages/features/captable.jsx:47 src/pages/features/captable.jsx:117
+#: src/pages/pricing.jsx:23
 msgid "Pooled investments"
 msgstr "Gepoolte Investments"
 
 #: src/pages/features/captable.jsx:119
 msgid "Pooled investments are common in many countries, Ledgy helps you keep them organized"
-msgstr "Gepoolte Investitionen sind in vielen Ländern üblich. Ledgy hilft dir, sie zu organisieren."
+msgstr "Gepoolte Investitionen sind in vielen Ländern üblich. Ledgy hilft dir, sie zu organisieren"
 
-#: src/pages/features/investors.jsx:59
-#: src/pages/features/investors.jsx:122
+#: src/pages/features/investors.jsx:59 src/pages/features/investors.jsx:122
 #: src/pages/features/investors.jsx:128
 msgid "Portfolio history"
 msgstr "Portfolio-Historie"
 
-#: src/layouts/index.jsx:62
-#: src/layouts/index.jsx:204
-#: src/pages/pricing.jsx:117
-#: src/pages/pricing.jsx:126
+#: src/layouts/index.jsx:62 src/layouts/index.jsx:204 src/pages/pricing.jsx:121
+#: src/pages/pricing.jsx:130
 msgid "Pricing"
 msgstr "Preise"
 
-#: src/pages/pricing.jsx:37
+#: src/pages/pricing.jsx:41
 msgid "Priority support"
 msgstr "Prioritätssupport"
 
-#: src/layouts/index.jsx:124
-#: src/pages/privacy.jsx:21
-#: src/pages/privacy.jsx:29
+#: src/layouts/index.jsx:124 src/pages/privacy.jsx:21 src/pages/privacy.jsx:29
 msgid "Privacy"
 msgstr "Datenschutz"
 
@@ -921,8 +888,7 @@ msgstr "Datenschutzrichtlinie"
 msgid "Privacy made in Europe"
 msgstr "Datenschutz aus Europa"
 
-#: src/pages/privacy.jsx:22
-#: src/pages/privacy.jsx:45
+#: src/pages/privacy.jsx:22 src/pages/privacy.jsx:45
 msgid "Privacy made in Europe. Because your equity data is not for everyone."
 msgstr "Datenschutz made in Europe. Weil deine Beteiligungsdaten nicht jeder kennen sollte."
 
@@ -934,8 +900,7 @@ msgstr "Pro-rata Verteilung"
 msgid "Product"
 msgstr "Produkt"
 
-#: src/pages/features/investors.jsx:53
-#: src/pages/features/investors.jsx:109
+#: src/pages/features/investors.jsx:53 src/pages/features/investors.jsx:109
 msgid "Professional portfolio"
 msgstr "Professionelles Portfolio"
 
@@ -959,8 +924,7 @@ msgstr "Finde Dokumente anhand der verknüpften Transaktionen z.B. zu einer Pers
 msgid "Quickly pull up legal documents by the information of their linked transactions"
 msgstr "Finde Dokumente anhand der Informationen der verknüpften Transaktionen"
 
-#: src/components/SecurityRow.jsx:22
-#: src/components/SecurityRow.jsx:37
+#: src/components/SecurityRow.jsx:22 src/components/SecurityRow.jsx:37
 #: src/pages/blog.jsx:49
 msgid "Read more"
 msgstr "Mehr erfahren"
@@ -969,12 +933,11 @@ msgstr "Mehr erfahren"
 msgid "Record of edits"
 msgstr "Historie der Änderungen"
 
-#: src/pages/features/investors.jsx:41
-#: src/pages/features/investors.jsx:76
+#: src/pages/features/investors.jsx:41 src/pages/features/investors.jsx:76
 msgid "Recurring reports"
 msgstr "Regelmässige Reports"
 
-#: src/pages/pricing.jsx:14
+#: src/pages/pricing.jsx:18
 msgid "Recurring reports, KPIs"
 msgstr "Regelmäßige Berichte, KPIs"
 
@@ -982,12 +945,11 @@ msgstr "Regelmäßige Berichte, KPIs"
 msgid "Report"
 msgstr "Bericht"
 
-#: src/pages/pricing.jsx:14
+#: src/pages/pricing.jsx:18
 msgid "Reporting"
 msgstr "Reporting"
 
-#: src/components/Feature.jsx:100
-#: src/pages/features.jsx:80
+#: src/components/Feature.jsx:100 src/pages/features.jsx:80
 msgid "Round & Exit Modeling"
 msgstr "Runden & Exit Modellierung"
 
@@ -995,8 +957,7 @@ msgstr "Runden & Exit Modellierung"
 msgid "Round Modeling"
 msgstr "Round Modeling"
 
-#: src/pages/features/modeling.jsx:20
-#: src/pages/features/modeling.jsx:30
+#: src/pages/features/modeling.jsx:20 src/pages/features/modeling.jsx:30
 msgid "Round and Exit Modeling"
 msgstr "Modellierung von Finanzierungsrunden und Exits"
 
@@ -1031,12 +992,10 @@ msgstr "Sicherer Datenraum"
 
 #: src/pages/features/collaboration.jsx:22
 msgid "Secure data room, audit trail and read-only access for investors; save costly due diligence tools."
-msgstr "Sicherer Data Room, Audit-Trail und Lesezugriff für Investoren sparen dir teure Due-Diligence Tools"
+msgstr "Sicherer Data Room, Audit-Trail und Lesezugriff für Investoren sparen dir teure Due-Diligence Tools."
 
-#: src/layouts/index.jsx:121
-#: src/pages/privacy.jsx:109
-#: src/pages/security.jsx:25
-#: src/pages/security.jsx:33
+#: src/layouts/index.jsx:121 src/pages/privacy.jsx:109
+#: src/pages/security.jsx:25 src/pages/security.jsx:33
 msgid "Security"
 msgstr "Sicherheit"
 
@@ -1082,7 +1041,7 @@ msgstr "Fully-diluted Ansicht des Cap Tables"
 
 #: src/layouts/index.jsx:81
 msgid "Sign up"
-msgstr ""
+msgstr "Registrieren"
 
 #: src/pages/features/modeling.jsx:120
 msgid "Simulation settings"
@@ -1096,10 +1055,8 @@ msgstr "Weltraumlift"
 msgid "Speed up your onboarding process with the bulk import feature"
 msgstr "Durch die Importtools kannst du innert kürzester Zeit loslegen"
 
-#: src/pages/features/captable.jsx:59
-#: src/pages/features/captable.jsx:157
-#: src/pages/features/esop.jsx:54
-#: src/pages/features/esop.jsx:152
+#: src/pages/features/captable.jsx:59 src/pages/features/captable.jsx:157
+#: src/pages/features/esop.jsx:54 src/pages/features/esop.jsx:152
 msgid "Spreadsheet importer"
 msgstr "Tabellenimport"
 
@@ -1129,15 +1086,15 @@ msgstr "Gestalte Berichte nach deinen Bedürfnissen mit dem Rich-Text-Editor"
 
 #: src/components/NewsletterForm.jsx:52
 msgid "Subscribe"
-msgstr ""
+msgstr "Abonnieren"
 
 #: src/layouts/index.jsx:94
 msgid "Subscribe to the newsletter"
-msgstr ""
+msgstr "Newsletter abonnieren"
 
 #: src/pages/subscribed.jsx:15
 msgid "Subscription confirmed"
-msgstr ""
+msgstr "Abonnement bestätigt"
 
 #: src/pages/features/investors.jsx:78
 msgid "Successful companies share regular updates with their stakeholders, holding themselves accountable"
@@ -1147,8 +1104,7 @@ msgstr "Erfolgreiche Unternehmen teilen regelmäßig Updates mit ihren Stakehold
 msgid "Suggest changes"
 msgstr "Änderungen vorschlagen"
 
-#: src/pages/features/esop.jsx:36
-#: src/pages/features/esop.jsx:74
+#: src/pages/features/esop.jsx:36 src/pages/features/esop.jsx:74
 msgid "Supports everything"
 msgstr "Unterstützt alles"
 
@@ -1184,8 +1140,7 @@ msgstr "Nutzungsbedingungen"
 msgid "The Ledgy Blog"
 msgstr "Der Ledgy-Blog"
 
-#: src/layouts/index.jsx:385
-#: src/pages/index.jsx:19
+#: src/layouts/index.jsx:385 src/pages/index.jsx:19
 msgid "The New Standard in Equity Management"
 msgstr "Der Neue Standard des Equity Management"
 
@@ -1245,8 +1200,7 @@ msgstr "Behalte den Überblick über Ausübung, Kündigung und Verfall"
 msgid "Track your valuations and understand the history in terms of percentage and number of shares"
 msgstr "Verfolge die Unternehmensbewertung und verstehe die Historie in Bezug auf prozentuale und absolute Verteilung"
 
-#: src/pages/features/captable.jsx:41
-#: src/pages/features/captable.jsx:76
+#: src/pages/features/captable.jsx:41 src/pages/features/captable.jsx:76
 msgid "Transaction-based"
 msgstr "Transaktionsbasiert"
 
@@ -1266,12 +1220,11 @@ msgstr "Transparente Historie"
 msgid "Trust your Cap Table"
 msgstr "Vertraue deinem Cap Table"
 
-#: src/pages/pricing.jsx:146
+#: src/pages/pricing.jsx:150
 msgid "Try 30 days free"
 msgstr "30 Tage gratis testen"
 
-#: src/pages/pricing.jsx:21
-#: src/pages/security.jsx:92
+#: src/pages/pricing.jsx:25 src/pages/security.jsx:92
 msgid "Two-factor authentication"
 msgstr "2-Faktor-Authentisierung"
 
@@ -1299,23 +1252,23 @@ msgstr "Verstehe die Auswirkungen von Liquidationspräferenzen"
 msgid "Unforgeable proof that your documents were not modified since the certification"
 msgstr "Fälschungssicherer Nachweis, dass deine Dokumente seit der Zertifizierung nicht verändert wurden"
 
-#: src/pages/pricing.jsx:40
+#: src/pages/pricing.jsx:44
 msgid "Unlimited"
 msgstr "Unlimitiert"
 
-#: src/pages/pricing.jsx:39
+#: src/pages/pricing.jsx:43
 msgid "Unlimited admins"
 msgstr "Unlimitierte Admins"
 
-#: src/pages/pricing.jsx:38
+#: src/pages/pricing.jsx:42
 msgid "Unlimited rounds & scenarios"
 msgstr "Beliebige Runden & Szenarien"
 
-#: src/pages/pricing.jsx:17
+#: src/pages/pricing.jsx:21
 msgid "Up to 50 MB"
 msgstr "Bis zu 50 MB"
 
-#: src/pages/pricing.jsx:29
+#: src/pages/pricing.jsx:33
 msgid "Up to 500 MB"
 msgstr "Bis zu 500 MB"
 
@@ -1351,7 +1304,7 @@ msgstr "VAT-Nummer"
 msgid "Valuation"
 msgstr "Bewertung"
 
-#: src/pages/pricing.jsx:30
+#: src/pages/pricing.jsx:34
 msgid "Vesting, expiry, maturity"
 msgstr "Vesting, Verfall, Maturität"
 
@@ -1403,9 +1356,11 @@ msgstr "Bei der Rundenmodellierung zeigt der Cap Table die Verteilung danach"
 msgid "Yoko graduated from ETH and Oxford and was president of Swissloop, enabling the team to win the 3rd price at the SpaceX Hyperloop competition"
 msgstr "Yoko hat ihren Physik Master an der ETH und in Oxford gemacht und war Präsident von Swissloop, wo sie dem Team zum dritten Platz beim SpaceX Hyperloop Wettbewerb verholfen hat"
 
-#: src/pages/pricing.jsx:181
+#: src/pages/pricing.jsx:185
 msgid "You get a <0>20% discount</0> on Premium if your startup helps reducing carbon emissions.<1/><2>Write us</2> about your impact to see if you qualify."
 msgstr ""
+"Du bekommst <0>20% Discount</0> auf den Premium-Plan, wenn dein Startup nachweislich Emissionen reduziert.<1/>\n"
+"<2>Schreib’ uns</2> über deinen Impact, um herauszufinden, ob das auf dein Startup zutrifft."
 
 #: src/components/SecurityRow.jsx:31
 msgid "Your data is safe with us"
@@ -1429,7 +1384,7 @@ msgstr "Cap Table, Aktienbuch, Aktienregister, Startup, Modellierung, Finanzieru
 
 #: src/layouts/index.jsx:98
 msgid "for monthly updates on new features and start-up resources"
-msgstr ""
+msgstr "für monatliche Updates über neue Features und Startup-Ressourcen"
 
 #: src/pages/features/esop.jsx:37
 msgid "from options, to phantom and vested stock"
@@ -1447,12 +1402,11 @@ msgstr "helfen dir deinen Investoren gegenüber professionell aufzutreten"
 msgid "modeling a new round, including convertibles"
 msgstr "bei der Modellierung neuer Runden, einschließlich Wandeldarlehen"
 
-#: src/pages/pricing.jsx:147
+#: src/pages/pricing.jsx:151
 msgid "per stakeholder per month"
 msgstr "pro Stakeholder pro Monat"
 
-#: src/pages/features/captable.jsx:60
-#: src/pages/features/esop.jsx:55
+#: src/pages/features/captable.jsx:60 src/pages/features/esop.jsx:55
 msgid "save time and focus on what matters"
 msgstr "Spare Zeit und konzentriere dich auf Wichtiges"
 
@@ -1504,6 +1458,6 @@ msgstr "bei der Planung deiner nächsten Finanzierungsrunde"
 msgid "with a single click"
 msgstr "mit einem einzigen Klick"
 
-#: src/pages/pricing.jsx:144
+#: src/pages/pricing.jsx:148
 msgid "€2"
 msgstr "€2"

--- a/src/locale/de/messages.po
+++ b/src/locale/de/messages.po
@@ -1384,6 +1384,10 @@ msgstr "durch Liquidationspräferenzen"
 msgid "cap table, stock ledger, share register, startup, modeling, financing round, equity, esop, phantom, option plan, virtual, portfolio, reporting, investors"
 msgstr "Cap Table, Aktienbuch, Aktienregister, Startup, Modellierung, Finanzierungsrunde, Exit, ESOP, VSOP, Beteiligungsplan, Unternehmensbeteiligung, Mitarbeiterbeteiligung, Optionspläne, virtuelle Beteiligung, Reporting, Investor, Portfolio"
 
+#: src/layouts/index.jsx:94
+msgid "for monthly updates on new features and start-up resources"
+msgstr ""
+
 #: src/pages/pricing.jsx:38
 msgid "free"
 msgstr "Gratis"

--- a/src/locale/de/messages.po
+++ b/src/locale/de/messages.po
@@ -227,7 +227,7 @@ msgstr "Optionen für die Massenerfassung"
 msgid "Calculates waterfall analysis of liquidation preferences across all rounds"
 msgstr "Berechnet die Wasserfallanalyse der Liquidationspräferenzen über alle Runden hinweg"
 
-#: src/layouts/index.jsx:187
+#: src/layouts/index.jsx:185
 msgid "Cap Table"
 msgstr "Cap Table"
 
@@ -243,7 +243,7 @@ msgstr "Cap Table während der Finanzierungsrundensimulation"
 msgid "Cap table management"
 msgstr "Cap Table-Verwaltung"
 
-#: src/layouts/index.jsx:125
+#: src/layouts/index.jsx:123
 msgid "Career"
 msgstr "Karriere"
 
@@ -260,7 +260,7 @@ msgstr "Timo programmiert seit seiner Schulzeit, wurde für die beste Masterarbe
 msgid "Collaboration & Due Diligence"
 msgstr "Zusammenarbeit & Due Diligence"
 
-#: src/layouts/index.jsx:108
+#: src/layouts/index.jsx:106
 msgid "Company"
 msgstr "Unternehmen"
 
@@ -281,7 +281,7 @@ msgstr "Umfassende Transaktionshistorie"
 msgid "Contact"
 msgstr "Kontakt"
 
-#: src/layouts/index.jsx:128
+#: src/layouts/index.jsx:126
 msgid "Contact & Imprint"
 msgstr "Kontakt & Impressum"
 
@@ -297,8 +297,8 @@ msgstr "Kontaktiere uns"
 msgid "Content-Security-Policy"
 msgstr "Content-Security-Policy"
 
-#: src/pages/subscribed.jsx:44
-msgid "Continue to site"
+#: src/pages/subscribed.jsx:40
+msgid "Continue exploring"
 msgstr ""
 
 #: src/pages/features/modeling.jsx:168
@@ -317,7 +317,7 @@ msgstr "In Transaktionen umwandeln"
 msgid "Convertibles"
 msgstr "Wandeldarlehen"
 
-#: src/layouts/index.jsx:221
+#: src/layouts/index.jsx:219
 msgid "Cookie Policy"
 msgstr "Cookie-Richtlinie"
 
@@ -389,7 +389,7 @@ msgstr "Hilft dein Startup, die Klimakrise zu lösen?"
 msgid "Download holding confirmations with a single click"
 msgstr "Holdingbestätigungen mit einem einzigen Klick herunterladen"
 
-#: src/layouts/index.jsx:196
+#: src/layouts/index.jsx:194
 msgid "Due Diligence"
 msgstr "Due Diligence"
 
@@ -425,7 +425,7 @@ msgstr "Elektronische Signaturen<0/>"
 msgid "Email notification about upcoming vesting event"
 msgstr "E-Mail-Benachrichtigung über bevorstehende Vesting-Ereignisse"
 
-#: src/layouts/index.jsx:193
+#: src/layouts/index.jsx:191
 msgid "Employee Incentives"
 msgstr "Mitarbeiter​​​​beteiligungen"
 
@@ -486,7 +486,7 @@ msgstr "Jedes Unternehmen hat KPIs und Investoren lieben es, sie in Echtzeit zu 
 msgid "Exit modeling"
 msgstr "Exit-Modellierung"
 
-#: src/layouts/index.jsx:144
+#: src/layouts/index.jsx:142
 msgid "FAQ"
 msgstr "FAQ"
 
@@ -525,7 +525,7 @@ msgstr "Für noch mehr Sicherheit der Nutzerkonten. Übrigens, unsere Implementi
 msgid "Founder of Meisser Economics, Bitcoin Association Switzerland, and Wuala"
 msgstr "Gründer von Meisser Economics, Bitcoin Association Schweiz und Wuala"
 
-#: src/layouts/index.jsx:224
+#: src/layouts/index.jsx:222
 msgid "GDPR"
 msgstr "GDPR"
 
@@ -562,15 +562,15 @@ msgstr "Vermeide kostspielige Fehler"
 msgid "Get your cap table and employee participation plans right, from the beginning. Make your financing rounds a success and engage your investors and employees. Know your data is safe and compliant."
 msgstr "Erstelle deinen Cap Table und deine Mitarbeiterbeteiligungspläne von Anfang an richtig. Bringe deine Finanzierungsrunden zum Erfolg und motiviere deine Investoren und Mitarbeiter. Sei dir sicher, dass deine Daten gut aufgehoben sind."
 
-#: src/layouts/index.jsx:384
+#: src/layouts/index.jsx:382
 msgid "Get your cap table and employee participation plans right, from the beginning. Make your financing rounds a success and engage your investors and employees. Know your data is safe and compliant. Try now for free!"
 msgstr "Erstelle deinen Cap Table und Mitarbeiterbeteiligungspläne von Anfang an richtig. Bringe deine Finanzierungsrunden zum Erfolg und motiviere deine Investoren und Mitarbeiter. Sei unbesorgt, dass deine Daten sicher und konform sind. Jetzt kostenlos testen!"
 
-#: src/layouts/index.jsx:141
+#: src/layouts/index.jsx:139
 msgid "Getting Started"
 msgstr "Erste Schritte"
 
-#: src/pages/subscribed.jsx:47
+#: src/pages/subscribed.jsx:43
 msgid "Go to Ledgy app"
 msgstr ""
 
@@ -595,7 +595,7 @@ msgstr "HTTP-Header verhindern Cross-Site-Scripting und Code-Injection (<0>A+-Ra
 msgid "Healthcare & technology venture capital since 2001"
 msgstr "Healthcare & technology venture capital since 2001"
 
-#: src/layouts/index.jsx:136
+#: src/layouts/index.jsx:134
 msgid "Help"
 msgstr "Hilfe"
 
@@ -665,7 +665,7 @@ msgstr "Investor Relations & Portfolio"
 msgid "Investor portfolio"
 msgstr "Investoren-Portfolio"
 
-#: src/layouts/index.jsx:199
+#: src/layouts/index.jsx:197
 msgid "Investors"
 msgstr "Investor Relations"
 
@@ -713,7 +713,7 @@ msgstr "Key performance indicators"
 msgid "Kpi chart"
 msgstr "KPI-Diagramm"
 
-#: src/layouts/index.jsx:256
+#: src/layouts/index.jsx:254
 msgid "Language"
 msgstr "Sprache"
 
@@ -741,7 +741,7 @@ msgstr "Ledgy macht es einfach, eine Investition mit einer pro-rata Verteilung z
 msgid "Ledgy scales with your needs. Free for startups, powerful for grown-ups."
 msgstr "Ledgy skaliert mit deinen Anforderungen. Kostenlos für Startups, leistungsstark für größere Firmen."
 
-#: src/layouts/index.jsx:210
+#: src/layouts/index.jsx:208
 msgid "Legal"
 msgstr "Legal"
 
@@ -785,7 +785,7 @@ msgstr "Marius hat sein Studium in Informatik an der Universität Mailand abgesc
 msgid "Meet the team behind Ledgy that went out to help startups thrive. Learn more about the people who trust in us."
 msgstr "Lerne das Team hinter Ledgy kennen, das sich zum Ziel gesetzt hat, Start-ups in ihrem Wachstum zu unterstützen. Erfahre mehr über die Menschen, die uns vertrauen."
 
-#: src/layouts/index.jsx:190
+#: src/layouts/index.jsx:188
 msgid "Modeling"
 msgstr "Modellierung"
 
@@ -880,7 +880,7 @@ msgstr "Prioritätssupport"
 msgid "Privacy"
 msgstr "Datenschutz"
 
-#: src/layouts/index.jsx:218
+#: src/layouts/index.jsx:216
 msgid "Privacy Policy"
 msgstr "Datenschutzrichtlinie"
 
@@ -896,7 +896,7 @@ msgstr "Datenschutz made in Europe. Weil deine Beteiligungsdaten nicht jeder ken
 msgid "Pro-rata distribution"
 msgstr "Pro-rata Verteilung"
 
-#: src/layouts/index.jsx:179
+#: src/layouts/index.jsx:177
 msgid "Product"
 msgstr "Produkt"
 
@@ -1039,6 +1039,10 @@ msgstr "Teile deine Szenarien als PDF, einschließlich Bewertungen, Investitione
 msgid "Show cap table fully diluted"
 msgstr "Fully-diluted Ansicht des Cap Tables"
 
+#: src/layouts/index.jsx:77
+msgid "Sign up"
+msgstr ""
+
 #: src/pages/features/modeling.jsx:120
 msgid "Simulation settings"
 msgstr "Simulationseinstellungen"
@@ -1081,12 +1085,11 @@ msgid "Style your reports to your needs with the rich-text editor"
 msgstr "Gestalte Berichte nach deinen Bedürfnissen mit dem Rich-Text-Editor"
 
 #: src/components/SignupForm.jsx:52
-#: src/layouts/index.jsx:78
 msgid "Subscribe"
 msgstr ""
 
-#: src/layouts/index.jsx:92
-msgid "Subscribe to our newsletter"
+#: src/layouts/index.jsx:90
+msgid "Subscribe to the newsletter"
 msgstr ""
 
 #: src/pages/subscribed.jsx:15
@@ -1129,7 +1132,7 @@ msgstr "Team"
 msgid "Technical data"
 msgstr "Technische Daten"
 
-#: src/layouts/index.jsx:215
+#: src/layouts/index.jsx:213
 msgid "Terms of Service"
 msgstr "Nutzungsbedingungen"
 
@@ -1373,15 +1376,11 @@ msgstr "und Änderungprotokoll vereinfachen Due Diligence"
 msgid "and numbered shares are natively supported"
 msgstr "und Aktiennummerierung wird nativ unterstützt"
 
-#: src/layouts/index.jsx:96
-msgid "and stay up-to-date with everything your start-up needs"
-msgstr ""
-
 #: src/pages/features/modeling.jsx:60
 msgid "by liquidation preferences"
 msgstr "durch Liquidationspräferenzen"
 
-#: src/layouts/index.jsx:392
+#: src/layouts/index.jsx:390
 msgid "cap table, stock ledger, share register, startup, modeling, financing round, equity, esop, phantom, option plan, virtual, portfolio, reporting, investors"
 msgstr "Cap Table, Aktienbuch, Aktienregister, Startup, Modellierung, Finanzierungsrunde, Exit, ESOP, VSOP, Beteiligungsplan, Unternehmensbeteiligung, Mitarbeiterbeteiligung, Optionspläne, virtuelle Beteiligung, Reporting, Investor, Portfolio"
 

--- a/src/locale/de/messages.po
+++ b/src/locale/de/messages.po
@@ -6,10 +6,10 @@ msgstr ""
 "Content-Transfer-Encoding: 8bit\n"
 "Plural-Forms: nplurals=2; plural=(n != 1);\n"
 "POT-Creation-Date: 2018-09-12T18:40:54.619Z\n"
-"PO-Revision-Date: 2019-07-05 12:06+0200\n"
+"PO-Revision-Date: 2019-07-05 12:24+0200\n"
 "Language: de\n"
 "Report-Msgid-Bugs-To: \n"
-"Last-Translator: \n"
+"Last-Translator: Timo Horstschäfer <timo@ledgy.com>\n"
 "Language-Team: \n"
 "X-Generator: Poedit 2.2.1\n"
 
@@ -49,7 +49,7 @@ msgstr "Für jedes Dokument wird beim Hochladen automatisch ein Zertifikat auf d
 msgid "A stakeholder is any holder of shares, (phantom) options, warrants, or convertibles.<0/>It does not include the company treasury or incentive pools."
 msgstr "Ein Stakeholder ist Halter von Anteilen, Optionen, Phantom-Anteilen, Warrants oder Wandeldarlehen.<0/>Die Firma selbst oder Beteiligungspools werden nicht eingerechnet."
 
-#: src/layouts/index.jsx:115 src/pages/about-us.jsx:17
+#: src/layouts/index.jsx:119 src/pages/about-us.jsx:17
 #: src/pages/about-us.jsx:25
 msgid "About us"
 msgstr "Über uns"
@@ -194,7 +194,7 @@ msgstr "Blockchain-Zertifizierung"
 msgid "Blockchain notary"
 msgstr "Blockchain-Notar"
 
-#: src/layouts/index.jsx:65 src/layouts/index.jsx:118 src/layouts/index.jsx:158
+#: src/layouts/index.jsx:65 src/layouts/index.jsx:122 src/layouts/index.jsx:162
 #: src/pages/blog.jsx:61
 msgid "Blog"
 msgstr "Blog"
@@ -227,7 +227,7 @@ msgstr "Optionen für die Massenerfassung"
 msgid "Calculates waterfall analysis of liquidation preferences across all rounds"
 msgstr "Berechnet die Wasserfallanalyse der Liquidationspräferenzen über alle Runden hinweg"
 
-#: src/layouts/index.jsx:189
+#: src/layouts/index.jsx:193
 msgid "Cap Table"
 msgstr "Cap Table"
 
@@ -243,7 +243,7 @@ msgstr "Cap Table während der Finanzierungsrundensimulation"
 msgid "Cap table management"
 msgstr "Cap Table-Verwaltung"
 
-#: src/layouts/index.jsx:127
+#: src/layouts/index.jsx:131
 msgid "Career"
 msgstr "Karriere"
 
@@ -264,7 +264,7 @@ msgstr "Zusammenarbeit & Due Diligence"
 msgid "Coming soon"
 msgstr "Bald verfügbar"
 
-#: src/layouts/index.jsx:110
+#: src/layouts/index.jsx:114
 msgid "Company"
 msgstr "Unternehmen"
 
@@ -285,7 +285,7 @@ msgstr "Umfassende Transaktionshistorie"
 msgid "Contact"
 msgstr "Kontakt"
 
-#: src/layouts/index.jsx:130
+#: src/layouts/index.jsx:134
 msgid "Contact & Imprint"
 msgstr "Kontakt & Impressum"
 
@@ -300,10 +300,6 @@ msgstr "Kontaktiere uns"
 #: src/pages/security.jsx:142
 msgid "Content-Security-Policy"
 msgstr "Content-Security-Policy"
-
-#: src/pages/subscribed.jsx:40
-msgid "Continue exploring"
-msgstr "Weiterstöbern"
 
 #: src/pages/features/modeling.jsx:168
 msgid "Convert financing round"
@@ -321,7 +317,7 @@ msgstr "In Transaktionen umwandeln"
 msgid "Convertibles"
 msgstr "Wandeldarlehen"
 
-#: src/layouts/index.jsx:223
+#: src/layouts/index.jsx:227
 msgid "Cookie Policy"
 msgstr "Cookie-Richtlinie"
 
@@ -393,7 +389,7 @@ msgstr "Hilft dein Startup, die Klimakrise zu lösen?"
 msgid "Download holding confirmations with a single click"
 msgstr "Holdingbestätigungen mit einem einzigen Klick herunterladen"
 
-#: src/layouts/index.jsx:198
+#: src/layouts/index.jsx:202
 msgid "Due Diligence"
 msgstr "Due Diligence"
 
@@ -429,7 +425,7 @@ msgstr "Elektronische Signaturen <0/>"
 msgid "Email notification about upcoming vesting event"
 msgstr "E-Mail-Benachrichtigung über bevorstehende Vesting-Ereignisse"
 
-#: src/layouts/index.jsx:195
+#: src/layouts/index.jsx:199
 msgid "Employee Incentives"
 msgstr "Mitarbeiter​​​​beteiligungen"
 
@@ -450,7 +446,7 @@ msgstr "Motiviere deine Mitarbeiter"
 msgid "Enjoy the highest security standards"
 msgstr "Geniesse die höchsten Sicherheitsstandards"
 
-#: src/components/NewsletterForm.jsx:43
+#: src/components/NewsletterForm.jsx:47
 msgid "Enter your email…"
 msgstr "Gebe deine E-Mail-Adresse ein…"
 
@@ -486,11 +482,11 @@ msgstr "Jedes Unternehmen hat KPIs und Investoren lieben es, sie in Echtzeit zu 
 msgid "Exit modeling"
 msgstr "Exit-Modellierung"
 
-#: src/layouts/index.jsx:146
+#: src/layouts/index.jsx:150
 msgid "FAQ"
 msgstr "FAQ"
 
-#: src/layouts/index.jsx:59 src/layouts/index.jsx:186
+#: src/layouts/index.jsx:59 src/layouts/index.jsx:190
 #: src/pages/features/captable.jsx:21 src/pages/features/collaboration.jsx:21
 #: src/pages/features/esop.jsx:16 src/pages/features/investors.jsx:21
 #: src/pages/features/modeling.jsx:21 src/pages/features.jsx:14
@@ -529,7 +525,7 @@ msgstr "Gründer von Meisser Economics, Bitcoin Association Schweiz und Wuala"
 msgid "Free"
 msgstr "Gratis"
 
-#: src/layouts/index.jsx:226
+#: src/layouts/index.jsx:230
 msgid "GDPR"
 msgstr "GDPR"
 
@@ -566,17 +562,13 @@ msgstr "Vermeide kostspielige Fehler"
 msgid "Get your cap table and employee participation plans right, from the beginning. Make your financing rounds a success and engage your investors and employees. Know your data is safe and compliant."
 msgstr "Erstelle deinen Cap Table und deine Mitarbeiterbeteiligungspläne von Anfang an richtig. Bringe deine Finanzierungsrunden zum Erfolg und motiviere deine Investoren und Mitarbeiter. Sei dir sicher, dass deine Daten gut aufgehoben sind."
 
-#: src/layouts/index.jsx:386
+#: src/layouts/index.jsx:390
 msgid "Get your cap table and employee participation plans right, from the beginning. Make your financing rounds a success and engage your investors and employees. Know your data is safe and compliant. Try now for free!"
 msgstr "Erstelle deinen Cap Table und Mitarbeiterbeteiligungspläne von Anfang an richtig. Bringe deine Finanzierungsrunden zum Erfolg und motiviere deine Investoren und Mitarbeiter. Sei unbesorgt, dass deine Daten sicher und konform sind. Jetzt kostenlos testen!"
 
-#: src/layouts/index.jsx:143
+#: src/layouts/index.jsx:147
 msgid "Getting Started"
 msgstr "Erste Schritte"
-
-#: src/pages/subscribed.jsx:43
-msgid "Go to Ledgy app"
-msgstr "Zur Ledgy-App"
 
 #: src/pages/features/esop.jsx:80
 msgid "Grant options, phantom options, warrants or add inverse vesting to stock transactions"
@@ -599,7 +591,7 @@ msgstr "HTTP-Header verhindern Cross-Site-Scripting und Code-Injection (<0>A+-Ra
 msgid "Healthcare & technology venture capital since 2001"
 msgstr "Healthcare & technology venture capital since 2001"
 
-#: src/layouts/index.jsx:138
+#: src/layouts/index.jsx:142
 msgid "Help"
 msgstr "Hilfe"
 
@@ -669,7 +661,7 @@ msgstr "Investor Relations & Portfolio"
 msgid "Investor portfolio"
 msgstr "Investoren-Portfolio"
 
-#: src/layouts/index.jsx:201
+#: src/layouts/index.jsx:205
 msgid "Investors"
 msgstr "Investor Relations"
 
@@ -717,7 +709,7 @@ msgstr "Key performance indicators"
 msgid "Kpi chart"
 msgstr "KPI-Diagramm"
 
-#: src/layouts/index.jsx:258
+#: src/layouts/index.jsx:262
 msgid "Language"
 msgstr "Sprache"
 
@@ -745,7 +737,7 @@ msgstr "Ledgy macht es einfach, eine Investition mit einer pro-rata Verteilung z
 msgid "Ledgy scales with your needs. Free for startups, powerful for grown-ups."
 msgstr "Ledgy skaliert mit deinen Anforderungen. Kostenlos für Startups, leistungsstark für größere Firmen."
 
-#: src/layouts/index.jsx:212
+#: src/layouts/index.jsx:216
 msgid "Legal"
 msgstr "Legal"
 
@@ -761,7 +753,7 @@ msgstr "Kontaktiere uns"
 msgid "Liquidation preferences"
 msgstr "Liquidationspräferenzen"
 
-#: src/layouts/index.jsx:74
+#: src/layouts/index.jsx:78
 msgid "Log In"
 msgstr "Anmelden"
 
@@ -789,7 +781,7 @@ msgstr "Marius hat sein Studium in Informatik an der Universität Mailand abgesc
 msgid "Meet the team behind Ledgy that went out to help startups thrive. Learn more about the people who trust in us."
 msgstr "Lerne das Team hinter Ledgy kennen, das sich zum Ziel gesetzt hat, Start-ups in ihrem Wachstum zu unterstützen. Erfahre mehr über die Menschen, die uns vertrauen."
 
-#: src/layouts/index.jsx:192
+#: src/layouts/index.jsx:196
 msgid "Modeling"
 msgstr "Modellierung"
 
@@ -821,7 +813,7 @@ msgstr "Die Nummerierung wird auf Konsistenz geprüft, was dir die Gewissheit gi
 msgid "One of the most active Swiss early-stage angel investors"
 msgstr "Einer der aktivsten Schweizer Angel-Investoren für Early Stage"
 
-#: src/components/NewsletterForm.jsx:56
+#: src/components/NewsletterForm.jsx:60
 msgid "Oops. This email address is invalid."
 msgstr "Upsala. Diese E-Mail-Adresse ist leider ungültig."
 
@@ -867,7 +859,7 @@ msgstr "Gepoolte Investitionen sind in vielen Ländern üblich. Ledgy hilft dir,
 msgid "Portfolio history"
 msgstr "Portfolio-Historie"
 
-#: src/layouts/index.jsx:62 src/layouts/index.jsx:204 src/pages/pricing.jsx:121
+#: src/layouts/index.jsx:62 src/layouts/index.jsx:208 src/pages/pricing.jsx:121
 #: src/pages/pricing.jsx:130
 msgid "Pricing"
 msgstr "Preise"
@@ -876,11 +868,11 @@ msgstr "Preise"
 msgid "Priority support"
 msgstr "Prioritätssupport"
 
-#: src/layouts/index.jsx:124 src/pages/privacy.jsx:21 src/pages/privacy.jsx:29
+#: src/layouts/index.jsx:128 src/pages/privacy.jsx:21 src/pages/privacy.jsx:29
 msgid "Privacy"
 msgstr "Datenschutz"
 
-#: src/layouts/index.jsx:220
+#: src/layouts/index.jsx:224
 msgid "Privacy Policy"
 msgstr "Datenschutzrichtlinie"
 
@@ -896,7 +888,7 @@ msgstr "Datenschutz made in Europe. Weil deine Beteiligungsdaten nicht jeder ken
 msgid "Pro-rata distribution"
 msgstr "Pro-rata Verteilung"
 
-#: src/layouts/index.jsx:181
+#: src/layouts/index.jsx:185
 msgid "Product"
 msgstr "Produkt"
 
@@ -994,7 +986,7 @@ msgstr "Sicherer Datenraum"
 msgid "Secure data room, audit trail and read-only access for investors; save costly due diligence tools."
 msgstr "Sicherer Data Room, Audit-Trail und Lesezugriff für Investoren sparen dir teure Due-Diligence Tools."
 
-#: src/layouts/index.jsx:121 src/pages/privacy.jsx:109
+#: src/layouts/index.jsx:125 src/pages/privacy.jsx:109
 #: src/pages/security.jsx:25 src/pages/security.jsx:33
 msgid "Security"
 msgstr "Sicherheit"
@@ -1039,7 +1031,7 @@ msgstr "Teile deine Szenarien als PDF, einschließlich Bewertungen, Investitione
 msgid "Show cap table fully diluted"
 msgstr "Fully-diluted Ansicht des Cap Tables"
 
-#: src/layouts/index.jsx:81
+#: src/layouts/index.jsx:85
 msgid "Sign up"
 msgstr "Registrieren"
 
@@ -1084,17 +1076,13 @@ msgstr "Sichere Passwörter"
 msgid "Style your reports to your needs with the rich-text editor"
 msgstr "Gestalte Berichte nach deinen Bedürfnissen mit dem Rich-Text-Editor"
 
-#: src/components/NewsletterForm.jsx:52
+#: src/components/NewsletterForm.jsx:56
 msgid "Subscribe"
 msgstr "Abonnieren"
 
-#: src/layouts/index.jsx:94
+#: src/layouts/index.jsx:98
 msgid "Subscribe to the newsletter"
 msgstr "Newsletter abonnieren"
-
-#: src/pages/subscribed.jsx:15
-msgid "Subscription confirmed"
-msgstr "Abonnement bestätigt"
 
 #: src/pages/features/investors.jsx:78
 msgid "Successful companies share regular updates with their stakeholders, holding themselves accountable"
@@ -1132,7 +1120,7 @@ msgstr "Team"
 msgid "Technical data"
 msgstr "Technische Daten"
 
-#: src/layouts/index.jsx:217
+#: src/layouts/index.jsx:221
 msgid "Terms of Service"
 msgstr "Nutzungsbedingungen"
 
@@ -1140,7 +1128,7 @@ msgstr "Nutzungsbedingungen"
 msgid "The Ledgy Blog"
 msgstr "Der Ledgy-Blog"
 
-#: src/layouts/index.jsx:385 src/pages/index.jsx:19
+#: src/layouts/index.jsx:389 src/pages/index.jsx:19
 msgid "The New Standard in Equity Management"
 msgstr "Der Neue Standard des Equity Management"
 
@@ -1378,11 +1366,11 @@ msgstr "und Aktiennummerierung wird nativ unterstützt"
 msgid "by liquidation preferences"
 msgstr "durch Liquidationspräferenzen"
 
-#: src/layouts/index.jsx:394
+#: src/layouts/index.jsx:398
 msgid "cap table, stock ledger, share register, startup, modeling, financing round, equity, esop, phantom, option plan, virtual, portfolio, reporting, investors"
 msgstr "Cap Table, Aktienbuch, Aktienregister, Startup, Modellierung, Finanzierungsrunde, Exit, ESOP, VSOP, Beteiligungsplan, Unternehmensbeteiligung, Mitarbeiterbeteiligung, Optionspläne, virtuelle Beteiligung, Reporting, Investor, Portfolio"
 
-#: src/layouts/index.jsx:98
+#: src/layouts/index.jsx:102
 msgid "for monthly updates on new features and start-up resources"
 msgstr "für monatliche Updates über neue Features und Startup-Ressourcen"
 

--- a/src/locale/de/messages.po
+++ b/src/locale/de/messages.po
@@ -13,19 +13,19 @@ msgstr ""
 "Language-Team: \n"
 "X-Generator: Poedit 2.2.3\n"
 
-#: src/pages/pricing.jsx:56
+#: src/pages/pricing.jsx:15
 msgid "1 round, 1 scenario"
 msgstr "1 Runde, 1 Szenario"
 
-#: src/pages/pricing.jsx:62
+#: src/pages/pricing.jsx:16
 msgid "2 admins, stakeholder access"
 msgstr "2 Admins, Investor-Zugriff"
 
-#: src/pages/pricing.jsx:95
-msgid "30 days trial"
-msgstr "30 Tage Probe"
+#: src/pages/pricing.jsx:83
+msgid "30-day trial"
+msgstr ""
 
-#: src/pages/pricing.jsx:127
+#: src/pages/pricing.jsx:28
 msgid "4 admins, view-only access"
 msgstr "4 Admins, Nur-Lese-Zugriff"
 
@@ -45,16 +45,19 @@ msgstr "<0>Ansicht</0> Lesezugriff auf alle Informationen für Due-Diligence"
 msgid "A certificate of each document is automatically stored on the bitcoin blockchain when uploading"
 msgstr "Für jedes Dokument wird beim Hochladen automatisch ein Zertifikat auf der Bitcoin-Blockchain gespeichert"
 
-#: src/pages/pricing.jsx:228
+#: src/pages/pricing.jsx:161
 msgid "A stakeholder is any holder of shares, (phantom) options, warrants, or convertibles.<0/>It does not include the company treasury or incentive pools."
 msgstr "Ein Stakeholder ist Halter von Anteilen, Optionen, Phantom-Anteilen, Warrants oder Wandeldarlehen.<0/>Die Firma selbst oder Beteiligungspools werden nicht eingerechnet."
 
-#: src/layouts/index.jsx:110 src/pages/about-us.jsx:17
+#: src/layouts/index.jsx:115
+#: src/pages/about-us.jsx:17
 #: src/pages/about-us.jsx:25
 msgid "About us"
 msgstr "Über uns"
 
-#: src/pages/pricing.jsx:60 src/pages/pricing.jsx:125 src/pages/pricing.jsx:188
+#: src/pages/pricing.jsx:16
+#: src/pages/pricing.jsx:28
+#: src/pages/pricing.jsx:39
 msgid "Access rights"
 msgstr "Zugriffsrechte"
 
@@ -86,23 +89,25 @@ msgstr "Vesting hinzufügen"
 msgid "Add vesting or inverse vesting to any transaction"
 msgstr "Hinzufügen von Vesting oder inversem Vesting zu jeder Transaktion"
 
-#: src/pages/features/modeling.jsx:53 src/pages/features/modeling.jsx:111
+#: src/pages/features/modeling.jsx:53
+#: src/pages/features/modeling.jsx:111
 msgid "Adjust your simulations"
 msgstr "Flexible Einstellungen"
 
-#: src/pages/pricing.jsx:172
+#: src/pages/pricing.jsx:36
 msgid "All Premium features"
 msgstr "Alle Premium-Features"
-
-#: src/pages/pricing.jsx:109
-msgid "All Standard features"
-msgstr "Alle Standard-Features"
 
 #: src/pages/security.jsx:184
 msgid "All data is stored at an <0>independent provider</0> in France"
 msgstr "Alle Daten werden bei einem <0>unabhängigen Anbieter</0> in Frankreich gespeichert"
 
-#: src/components/Feature.jsx:89 src/pages/features.jsx:23
+#: src/pages/pricing.jsx:25
+msgid "All standard features"
+msgstr ""
+
+#: src/components/Feature.jsx:89
+#: src/pages/features.jsx:23
 msgid "All you need in one place"
 msgstr "Alles an einem Ort"
 
@@ -118,7 +123,8 @@ msgstr "Ein stets aktuelles Portfolio, von deinen Start-ups gepflegt"
 msgid "Analyze it by stakeholder, share class, stakeholder group and view it with all, outstanding or diluted shares"
 msgstr "Analysiere nach Stakeholder, Aktienklasse, Stakeholdergruppe, nur mit ausstehenden Anteilen oder verwässert"
 
-#: src/pages/features/esop.jsx:92 src/pages/pricing.jsx:115
+#: src/pages/features/esop.jsx:92
+#: src/pages/pricing.jsx:26
 msgid "Any vesting schedule"
 msgstr "Beliebiges Vesting"
 
@@ -142,7 +148,8 @@ msgstr "Wir bei Ledgy nehmen deine Sicherheit ernst. Sichere Passwörter, solide
 msgid "Attach doc to transaction"
 msgstr "Dokument an Transaktion anhängen"
 
-#: src/pages/features/captable.jsx:53 src/pages/features/captable.jsx:136
+#: src/pages/features/captable.jsx:53
+#: src/pages/features/captable.jsx:136
 msgid "Attach documents"
 msgstr "Dokumente anhängen"
 
@@ -194,12 +201,14 @@ msgstr "Blockchain-Zertifizierung"
 msgid "Blockchain notary"
 msgstr "Blockchain-Notar"
 
-#: src/layouts/index.jsx:64 src/layouts/index.jsx:113 src/layouts/index.jsx:153
+#: src/layouts/index.jsx:65
+#: src/layouts/index.jsx:118
+#: src/layouts/index.jsx:158
 #: src/pages/blog.jsx:61
 msgid "Blog"
 msgstr "Blog"
 
-#: src/pages/pricing.jsx:146
+#: src/pages/pricing.jsx:32
 msgid "Breakpoint & exit analyses"
 msgstr "Breakpoint & Exit-Analyse"
 
@@ -227,11 +236,12 @@ msgstr "Optionen für die Massenerfassung"
 msgid "Calculates waterfall analysis of liquidation preferences across all rounds"
 msgstr "Berechnet die Wasserfallanalyse der Liquidationspräferenzen über alle Runden hinweg"
 
-#: src/layouts/index.jsx:185
+#: src/layouts/index.jsx:189
 msgid "Cap Table"
 msgstr "Cap Table"
 
-#: src/components/Feature.jsx:99 src/pages/features.jsx:58
+#: src/components/Feature.jsx:99
+#: src/pages/features.jsx:58
 msgid "Cap Table Management"
 msgstr "Cap Table Management"
 
@@ -239,11 +249,11 @@ msgstr "Cap Table Management"
 msgid "Cap table during round modeling"
 msgstr "Cap Table während der Finanzierungsrundensimulation"
 
-#: src/pages/pricing.jsx:44
+#: src/pages/pricing.jsx:13
 msgid "Cap table management"
 msgstr "Cap Table-Verwaltung"
 
-#: src/layouts/index.jsx:123
+#: src/layouts/index.jsx:127
 msgid "Career"
 msgstr "Karriere"
 
@@ -255,16 +265,18 @@ msgstr "Wähle aus, ob nur Pools oder die Detailansicht mit den ausgegebenen Gra
 msgid "Coding since high school, Timo got an award for the best master thesis in computer science and worked one year as a computer engineer in robotics"
 msgstr "Timo programmiert seit seiner Schulzeit, wurde für die beste Masterarbeit in Computer Science ausgezeichnet und hat ein Jahr als Computer Engineer in der Robotik gearbeitet"
 
-#: src/components/Feature.jsx:101 src/pages/features/collaboration.jsx:20
+#: src/components/Feature.jsx:101
+#: src/pages/features/collaboration.jsx:20
 #: src/pages/features.jsx:104
 msgid "Collaboration & Due Diligence"
 msgstr "Zusammenarbeit & Due Diligence"
 
-#: src/layouts/index.jsx:106
+#: src/layouts/index.jsx:110
 msgid "Company"
 msgstr "Unternehmen"
 
-#: src/pages/features/modeling.jsx:47 src/pages/features/modeling.jsx:95
+#: src/pages/features/modeling.jsx:47
+#: src/pages/features/modeling.jsx:95
 #: src/pages/features/modeling.jsx:105
 msgid "Compare and share scenarios"
 msgstr "Szenarien vergleichen und teilen"
@@ -277,11 +289,12 @@ msgstr "Vervollständige dein Portfolio"
 msgid "Comprehensive transaction history"
 msgstr "Umfassende Transaktionshistorie"
 
-#: src/pages/contact.jsx:10 src/pages/contact.jsx:74
+#: src/pages/contact.jsx:10
+#: src/pages/contact.jsx:74
 msgid "Contact"
 msgstr "Kontakt"
 
-#: src/layouts/index.jsx:126
+#: src/layouts/index.jsx:130
 msgid "Contact & Imprint"
 msgstr "Kontakt & Impressum"
 
@@ -289,7 +302,8 @@ msgstr "Kontakt & Impressum"
 msgid "Contact data, usage statistics, and technical data"
 msgstr "Kontaktdaten, Nutzungsstatistiken und technische Daten"
 
-#: src/pages/pricing.jsx:165 src/pages/pricing.jsx:219
+#: src/pages/pricing.jsx:152
+#: src/pages/pricing.jsx:154
 msgid "Contact us"
 msgstr "Kontaktiere uns"
 
@@ -313,11 +327,11 @@ msgstr "Konvertiere das endgültige Szenario in Transaktionen mit nur zwei Klick
 msgid "Convert to transactions"
 msgstr "In Transaktionen umwandeln"
 
-#: src/pages/pricing.jsx:78
+#: src/pages/pricing.jsx:20
 msgid "Convertibles"
 msgstr "Wandeldarlehen"
 
-#: src/layouts/index.jsx:219
+#: src/layouts/index.jsx:223
 msgid "Cookie Policy"
 msgstr "Cookie-Richtlinie"
 
@@ -349,11 +363,12 @@ msgstr "Datenraum, Audit-Trail und schreibgeschützter Zugriff für Investoren e
 msgid "Digital entrepreneur and investor. Security, crypto & privacy expert"
 msgstr "Digital Entrepreneur und Investor. Security-, Crypto- & Privacy-Experte"
 
-#: src/pages/features/esop.jsx:137 src/pages/features/modeling.jsx:140
+#: src/pages/features/esop.jsx:137
+#: src/pages/features/modeling.jsx:140
 msgid "Diluted cap table"
 msgstr "Verwässerter Cap Table"
 
-#: src/pages/pricing.jsx:236
+#: src/pages/pricing.jsx:169
 msgid "Discover all features"
 msgstr "Entdecke alle Features"
 
@@ -373,15 +388,17 @@ msgstr "Dokumentverknüpfungen"
 msgid "Document management"
 msgstr "Dokumenteverwaltung"
 
-#: src/pages/pricing.jsx:66 src/pages/pricing.jsx:131 src/pages/pricing.jsx:194
+#: src/pages/pricing.jsx:17
+#: src/pages/pricing.jsx:29
+#: src/pages/pricing.jsx:40
 msgid "Document storage"
 msgstr "Dokumentenablage"
 
-#: src/pages/pricing.jsx:200
-msgid "Document workflows<0/>"
-msgstr "Dokumenten-Workflows<0/>"
+#: src/pages/pricing.jsx:43
+msgid "Document workflow <0/>"
+msgstr ""
 
-#: src/pages/pricing.jsx:242
+#: src/pages/pricing.jsx:175
 msgid "Does your startup tackle the climate crisis?"
 msgstr "Hilft dein Startup, die Klimakrise zu lösen?"
 
@@ -389,7 +406,7 @@ msgstr "Hilft dein Startup, die Klimakrise zu lösen?"
 msgid "Download holding confirmations with a single click"
 msgstr "Holdingbestätigungen mit einem einzigen Klick herunterladen"
 
-#: src/layouts/index.jsx:194
+#: src/layouts/index.jsx:198
 msgid "Due Diligence"
 msgstr "Due Diligence"
 
@@ -417,19 +434,20 @@ msgstr "EU-Datenschutz"
 msgid "Edit log"
 msgstr "Bearbeitungsprotokoll"
 
-#: src/pages/pricing.jsx:206
-msgid "Electronic signatures<0/>"
-msgstr "Elektronische Signaturen<0/>"
+#: src/pages/pricing.jsx:49
+msgid "Electronic signatures <0/>"
+msgstr ""
 
 #: src/pages/features/esop.jsx:123
 msgid "Email notification about upcoming vesting event"
 msgstr "E-Mail-Benachrichtigung über bevorstehende Vesting-Ereignisse"
 
-#: src/layouts/index.jsx:191
+#: src/layouts/index.jsx:195
 msgid "Employee Incentives"
 msgstr "Mitarbeiter​​​​beteiligungen"
 
-#: src/components/Feature.jsx:98 src/pages/features/esop.jsx:25
+#: src/components/Feature.jsx:98
+#: src/pages/features/esop.jsx:25
 #: src/pages/features.jsx:33
 msgid "Employee Participation Plans"
 msgstr "Mitarbeiterbeteiligungspläne"
@@ -438,7 +456,8 @@ msgstr "Mitarbeiterbeteiligungspläne"
 msgid "Encrypted connection"
 msgstr "Verschlüsselte Verbindung"
 
-#: src/pages/features/esop.jsx:48 src/pages/features/esop.jsx:109
+#: src/pages/features/esop.jsx:48
+#: src/pages/features/esop.jsx:109
 msgid "Engage your employees"
 msgstr "Motiviere deine Mitarbeiter"
 
@@ -446,13 +465,9 @@ msgstr "Motiviere deine Mitarbeiter"
 msgid "Enjoy the highest security standards"
 msgstr "Geniesse die höchsten Sicherheitsstandards"
 
-#: src/components/SignupForm.jsx:43
+#: src/components/NewsletterForm.jsx:43
 msgid "Enter your email…"
 msgstr "Gebe deine E-Mail-Adresse ein…"
-
-#: src/pages/pricing.jsx:161
-msgid "Enterprise"
-msgstr "Enterprise"
 
 #: src/pages/about-us.jsx:169
 msgid "Entrepreneur, business angel, founder of Doodle.com"
@@ -462,7 +477,8 @@ msgstr "Unternehmer, Business Angel, Gründer von Doodle.com"
 msgid "Entrepreneur, technologist, founder of Doodle.com"
 msgstr "Unternehmer, Technologe, Gründer von Doodle.com"
 
-#: src/pages/privacy.jsx:77 src/pages/privacy.jsx:129
+#: src/pages/privacy.jsx:77
+#: src/pages/privacy.jsx:129
 msgid "Equity data"
 msgstr "Aktiendaten"
 
@@ -470,7 +486,7 @@ msgstr "Aktiendaten"
 msgid "Equity data is too important to be accidentally tweaked in a spreadsheet"
 msgstr "Beteiligungsdaten sind zu wichtig, um sie versehentlich in einem Tabellendokument zu verändern"
 
-#: src/pages/pricing.jsx:113
+#: src/pages/pricing.jsx:26
 msgid "Equity plan management"
 msgstr "Beteiligungspläne"
 
@@ -482,18 +498,23 @@ msgstr "Europe’s symbiosis of early-stage VC funds and private investor networ
 msgid "Every company has KPIs, and investors love seeing them in real-time"
 msgstr "Jedes Unternehmen hat KPIs und Investoren lieben es, sie in Echtzeit zu verfolgen"
 
-#: src/pages/features/modeling.jsx:173 src/pages/features/modeling.jsx:186
+#: src/pages/features/modeling.jsx:173
+#: src/pages/features/modeling.jsx:186
 msgid "Exit modeling"
 msgstr "Exit-Modellierung"
 
-#: src/layouts/index.jsx:142
+#: src/layouts/index.jsx:146
 msgid "FAQ"
 msgstr "FAQ"
 
-#: src/layouts/index.jsx:58 src/layouts/index.jsx:181
-#: src/pages/features/captable.jsx:21 src/pages/features/collaboration.jsx:21
-#: src/pages/features/esop.jsx:16 src/pages/features/investors.jsx:21
-#: src/pages/features/modeling.jsx:21 src/pages/features.jsx:14
+#: src/layouts/index.jsx:59
+#: src/layouts/index.jsx:186
+#: src/pages/features/captable.jsx:21
+#: src/pages/features/collaboration.jsx:21
+#: src/pages/features/esop.jsx:16
+#: src/pages/features/investors.jsx:21
+#: src/pages/features/modeling.jsx:21
+#: src/pages/features.jsx:14
 msgid "Features"
 msgstr "Funktionen"
 
@@ -501,15 +522,17 @@ msgstr "Funktionen"
 msgid "Featuring unlimited share classes, treasury shares, pooled investments, and automatic share numbering"
 msgstr "Mit beliebig vielen Anteilsklassen, Treasury Anteilen, gepoolten Investitionen und automatischer Aktiennummerierung"
 
-#: src/pages/index.jsx:137
+#: src/pages/index.jsx:141
 msgid "Finally, I have a reliable overview of all our shares, employee grants, and their legal documents. So much better than the Excel I used before."
 msgstr "Endlich habe ich eine zuverlässige Übersicht über all unsere Aktien, Mitarbeiterdarlehen und die rechtlichen Dokumente dazu. Das ist so viel besser als Excel, das ich früher benutzt habe."
 
-#: src/pages/pricing.jsx:54 src/pages/pricing.jsx:119 src/pages/pricing.jsx:182
+#: src/pages/pricing.jsx:15
+#: src/pages/pricing.jsx:27
+#: src/pages/pricing.jsx:38
 msgid "Financing round modeling"
 msgstr "Modellierung von Runden"
 
-#: src/pages/index.jsx:151
+#: src/pages/index.jsx:155
 msgid "Find out why they trust us"
 msgstr "Warum sie uns vertrauen"
 
@@ -525,11 +548,15 @@ msgstr "Für noch mehr Sicherheit der Nutzerkonten. Übrigens, unsere Implementi
 msgid "Founder of Meisser Economics, Bitcoin Association Switzerland, and Wuala"
 msgstr "Gründer von Meisser Economics, Bitcoin Association Schweiz und Wuala"
 
-#: src/layouts/index.jsx:222
+#: src/pages/pricing.jsx:138
+msgid "Free"
+msgstr ""
+
+#: src/layouts/index.jsx:226
 msgid "GDPR"
 msgstr "GDPR"
 
-#: src/pages/index.jsx:40
+#: src/pages/index.jsx:44
 msgid "Get Started Free"
 msgstr "Kostenlos starten"
 
@@ -545,7 +572,7 @@ msgstr "Bekomme Benachrichtigungen zu wichtigen Vesting- und Verfallsdaten und b
 msgid "Get notified two weeks before a cliff or vesting ends or a grant expires to not miss using your participation plan for engaging your employees"
 msgstr "Lasse dich vor dem Ende eines Cliffs, Vestings oder Verfallsdatums benachrichtigen, damit du nicht die Chance verpasst, deine Mitarbeiter mit der Beteiligung zu motivieren"
 
-#: src/pages/pricing.jsx:86
+#: src/pages/pricing.jsx:140
 msgid "Get started"
 msgstr "Los geht’s"
 
@@ -553,7 +580,8 @@ msgstr "Los geht’s"
 msgid "Get started in minutes with the copy-paste spreadsheet importer"
 msgstr "Lege in wenigen Minuten mit dem Copy-Paste-Tool für bestehende Tabellen los"
 
-#: src/pages/features/modeling.jsx:41 src/pages/features/modeling.jsx:76
+#: src/pages/features/modeling.jsx:41
+#: src/pages/features/modeling.jsx:76
 #: src/pages/features/modeling.jsx:88
 msgid "Get the calculations right"
 msgstr "Vermeide kostspielige Fehler"
@@ -562,11 +590,11 @@ msgstr "Vermeide kostspielige Fehler"
 msgid "Get your cap table and employee participation plans right, from the beginning. Make your financing rounds a success and engage your investors and employees. Know your data is safe and compliant."
 msgstr "Erstelle deinen Cap Table und deine Mitarbeiterbeteiligungspläne von Anfang an richtig. Bringe deine Finanzierungsrunden zum Erfolg und motiviere deine Investoren und Mitarbeiter. Sei dir sicher, dass deine Daten gut aufgehoben sind."
 
-#: src/layouts/index.jsx:382
+#: src/layouts/index.jsx:386
 msgid "Get your cap table and employee participation plans right, from the beginning. Make your financing rounds a success and engage your investors and employees. Know your data is safe and compliant. Try now for free!"
 msgstr "Erstelle deinen Cap Table und Mitarbeiterbeteiligungspläne von Anfang an richtig. Bringe deine Finanzierungsrunden zum Erfolg und motiviere deine Investoren und Mitarbeiter. Sei unbesorgt, dass deine Daten sicher und konform sind. Jetzt kostenlos testen!"
 
-#: src/layouts/index.jsx:139
+#: src/layouts/index.jsx:143
 msgid "Getting Started"
 msgstr "Erste Schritte"
 
@@ -595,7 +623,7 @@ msgstr "HTTP-Header verhindern Cross-Site-Scripting und Code-Injection (<0>A+-Ra
 msgid "Healthcare & technology venture capital since 2001"
 msgstr "Healthcare & technology venture capital since 2001"
 
-#: src/layouts/index.jsx:134
+#: src/layouts/index.jsx:138
 msgid "Help"
 msgstr "Hilfe"
 
@@ -608,7 +636,8 @@ msgid "Holding confirmation"
 msgstr "Besitzbestätigung"
 
 #: src/pages/features/collaboration.jsx:59
-#: src/pages/features/collaboration.jsx:169 src/pages/pricing.jsx:72
+#: src/pages/features/collaboration.jsx:169
+#: src/pages/pricing.jsx:18
 msgid "Holding confirmations"
 msgstr "Besitzbestätigungen"
 
@@ -616,7 +645,7 @@ msgstr "Besitzbestätigungen"
 msgid "How we protect your information"
 msgstr "Wie wir deine Informationen schützen"
 
-#: src/pages/index.jsx:126
+#: src/pages/index.jsx:130
 msgid "I needed exactly that. Every founder should use Ledgy’s modeling tools for financing rounds!"
 msgstr "Genau das hat mir gefehlt. Jeder Gründer sollte Ledgys Modellierungswerkzeug für Finanzierungsrunden benutzen!"
 
@@ -656,8 +685,10 @@ msgstr "Intuitive, rechtsgültige und fehlerfreie Cap Tables von Anfang an, die 
 msgid "Investor & consultant (Farmy.ch, Flatfox.ch), founder of Students.ch"
 msgstr "Investor & Berater (Farmy.ch, Flatfox.ch), Gründer von Students.ch"
 
-#: src/components/Feature.jsx:102 src/pages/features/investors.jsx:20
-#: src/pages/features/investors.jsx:30 src/pages/features.jsx:126
+#: src/components/Feature.jsx:102
+#: src/pages/features/investors.jsx:20
+#: src/pages/features/investors.jsx:30
+#: src/pages/features.jsx:126
 msgid "Investor Relations & Portfolio"
 msgstr "Investor Relations & Portfolio"
 
@@ -665,7 +696,7 @@ msgstr "Investor Relations & Portfolio"
 msgid "Investor portfolio"
 msgstr "Investoren-Portfolio"
 
-#: src/layouts/index.jsx:197
+#: src/layouts/index.jsx:201
 msgid "Investors"
 msgstr "Investor Relations"
 
@@ -677,7 +708,7 @@ msgstr "Lade Gründer oder CFO ein, das Unternehmen zu verwalten und die Informa
 msgid "Invite your employees to track their stake and vesting in their Ledgy portfolio"
 msgstr "Lade deine Mitarbeiter dazu ein, ihre Beteiligung und Vesting-Pläne in ihrem Ledgy-Portfolio zu verfolgen"
 
-#: src/pages/index.jsx:100
+#: src/pages/index.jsx:104
 msgid "Join hundreds of companies"
 msgstr "Schliesse dich hunderten Startups an"
 
@@ -713,7 +744,7 @@ msgstr "Key performance indicators"
 msgid "Kpi chart"
 msgstr "KPI-Diagramm"
 
-#: src/layouts/index.jsx:254
+#: src/layouts/index.jsx:258
 msgid "Language"
 msgstr "Sprache"
 
@@ -737,11 +768,11 @@ msgstr "Erfahre mehr über Dokumentenverwaltung"
 msgid "Ledgy makes it easy to simulate an investment with a pro-rata distribution"
 msgstr "Ledgy macht es einfach, eine Investition mit einer pro-rata Verteilung zu simulieren"
 
-#: src/pages/pricing.jsx:16
+#: src/pages/pricing.jsx:118
 msgid "Ledgy scales with your needs. Free for startups, powerful for grown-ups."
 msgstr "Ledgy skaliert mit deinen Anforderungen. Kostenlos für Startups, leistungsstark für größere Firmen."
 
-#: src/layouts/index.jsx:208
+#: src/layouts/index.jsx:212
 msgid "Legal"
 msgstr "Legal"
 
@@ -753,7 +784,7 @@ msgstr "Rechtliche Dokumente zu jeder Transaktionen auf einen Blick"
 msgid "Let’s Get In Touch"
 msgstr "Kontaktiere uns"
 
-#: src/pages/pricing.jsx:143
+#: src/pages/pricing.jsx:31
 msgid "Liquidation preferences"
 msgstr "Liquidationspräferenzen"
 
@@ -785,11 +816,11 @@ msgstr "Marius hat sein Studium in Informatik an der Universität Mailand abgesc
 msgid "Meet the team behind Ledgy that went out to help startups thrive. Learn more about the people who trust in us."
 msgstr "Lerne das Team hinter Ledgy kennen, das sich zum Ziel gesetzt hat, Start-ups in ihrem Wachstum zu unterstützen. Erfahre mehr über die Menschen, die uns vertrauen."
 
-#: src/layouts/index.jsx:188
+#: src/layouts/index.jsx:192
 msgid "Modeling"
 msgstr "Modellierung"
 
-#: src/pages/pricing.jsx:121
+#: src/pages/pricing.jsx:27
 msgid "Multiple rounds, 3 scenarios"
 msgstr "Mehrere Runden, 3 Szenarien"
 
@@ -801,7 +832,7 @@ msgstr "Name, E-Mail, Adresse und alle anderen Angaben, die du machst. Für die 
 msgid "Nobody has any access to the equity data you provide. They are safely stored at a secure data center in France. Your stakeholders have no access and don’t get emails before you explicitly invite them"
 msgstr "Niemand hat Zugang zu den von dir angegebenen Aktiendaten. Sie werden sicher in einem geschützten Rechenzentrum in Frankreich gespeichert. Deine Stakeholder haben keinen Zugriff und erhalten keine E-Mails, bevor du sie nicht explizit einlädst"
 
-#: src/pages/pricing.jsx:137
+#: src/pages/pricing.jsx:30
 msgid "Notifications"
 msgstr "Benachrichtigungen"
 
@@ -817,7 +848,7 @@ msgstr "Die Nummerierung wird auf Konsistenz geprüft, was dir die Gewissheit gi
 msgid "One of the most active Swiss early-stage angel investors"
 msgstr "Einer der aktivsten Schweizer Angel-Investoren für Early Stage"
 
-#: src/components/SignupForm.jsx:56
+#: src/components/NewsletterForm.jsx:56
 msgid "Oops. This email address is invalid."
 msgstr "Upsala. Diese E-Mail-Adresse ist leider ungültig."
 
@@ -837,7 +868,7 @@ msgstr "Passwort-Verschlüsselung"
 msgid "Peer-reviewed code"
 msgstr "Code-Audits"
 
-#: src/pages/pricing.jsx:178
+#: src/pages/pricing.jsx:37
 msgid "Phone & chat, onboarding"
 msgstr "Telefon & Chat, Onboarding"
 
@@ -849,8 +880,9 @@ msgstr "Experimentiere mit gründer- oder investorenfreundlichen Rahmenbedingung
 msgid "Pooled investment"
 msgstr "Gepoolte Investments"
 
-#: src/pages/features/captable.jsx:47 src/pages/features/captable.jsx:117
-#: src/pages/pricing.jsx:75
+#: src/pages/features/captable.jsx:47
+#: src/pages/features/captable.jsx:117
+#: src/pages/pricing.jsx:19
 msgid "Pooled investments"
 msgstr "Gepoolte Investments"
 
@@ -858,29 +890,30 @@ msgstr "Gepoolte Investments"
 msgid "Pooled investments are common in many countries, Ledgy helps you keep them organized"
 msgstr "Gepoolte Investitionen sind in vielen Ländern üblich. Ledgy hilft dir, sie zu organisieren."
 
-#: src/pages/features/investors.jsx:59 src/pages/features/investors.jsx:122
+#: src/pages/features/investors.jsx:59
+#: src/pages/features/investors.jsx:122
 #: src/pages/features/investors.jsx:128
 msgid "Portfolio history"
 msgstr "Portfolio-Historie"
 
-#: src/pages/pricing.jsx:98
-msgid "Premium"
-msgstr "Premium"
-
-#: src/layouts/index.jsx:61 src/layouts/index.jsx:199 src/pages/pricing.jsx:15
-#: src/pages/pricing.jsx:24
+#: src/layouts/index.jsx:62
+#: src/layouts/index.jsx:204
+#: src/pages/pricing.jsx:117
+#: src/pages/pricing.jsx:126
 msgid "Pricing"
 msgstr "Preise"
 
-#: src/pages/pricing.jsx:176
+#: src/pages/pricing.jsx:37
 msgid "Priority support"
 msgstr "Prioritätssupport"
 
-#: src/layouts/index.jsx:119 src/pages/privacy.jsx:21 src/pages/privacy.jsx:29
+#: src/layouts/index.jsx:124
+#: src/pages/privacy.jsx:21
+#: src/pages/privacy.jsx:29
 msgid "Privacy"
 msgstr "Datenschutz"
 
-#: src/layouts/index.jsx:216
+#: src/layouts/index.jsx:220
 msgid "Privacy Policy"
 msgstr "Datenschutzrichtlinie"
 
@@ -888,7 +921,8 @@ msgstr "Datenschutzrichtlinie"
 msgid "Privacy made in Europe"
 msgstr "Datenschutz aus Europa"
 
-#: src/pages/privacy.jsx:22 src/pages/privacy.jsx:45
+#: src/pages/privacy.jsx:22
+#: src/pages/privacy.jsx:45
 msgid "Privacy made in Europe. Because your equity data is not for everyone."
 msgstr "Datenschutz made in Europe. Weil deine Beteiligungsdaten nicht jeder kennen sollte."
 
@@ -896,11 +930,12 @@ msgstr "Datenschutz made in Europe. Weil deine Beteiligungsdaten nicht jeder ken
 msgid "Pro-rata distribution"
 msgstr "Pro-rata Verteilung"
 
-#: src/layouts/index.jsx:177
+#: src/layouts/index.jsx:181
 msgid "Product"
 msgstr "Produkt"
 
-#: src/pages/features/investors.jsx:53 src/pages/features/investors.jsx:109
+#: src/pages/features/investors.jsx:53
+#: src/pages/features/investors.jsx:109
 msgid "Professional portfolio"
 msgstr "Professionelles Portfolio"
 
@@ -924,7 +959,8 @@ msgstr "Finde Dokumente anhand der verknüpften Transaktionen z.B. zu einer Pers
 msgid "Quickly pull up legal documents by the information of their linked transactions"
 msgstr "Finde Dokumente anhand der Informationen der verknüpften Transaktionen"
 
-#: src/components/SecurityRow.jsx:22 src/components/SecurityRow.jsx:37
+#: src/components/SecurityRow.jsx:22
+#: src/components/SecurityRow.jsx:37
 #: src/pages/blog.jsx:49
 msgid "Read more"
 msgstr "Mehr erfahren"
@@ -933,11 +969,12 @@ msgstr "Mehr erfahren"
 msgid "Record of edits"
 msgstr "Historie der Änderungen"
 
-#: src/pages/features/investors.jsx:41 src/pages/features/investors.jsx:76
+#: src/pages/features/investors.jsx:41
+#: src/pages/features/investors.jsx:76
 msgid "Recurring reports"
 msgstr "Regelmässige Reports"
 
-#: src/pages/pricing.jsx:50
+#: src/pages/pricing.jsx:14
 msgid "Recurring reports, KPIs"
 msgstr "Regelmäßige Berichte, KPIs"
 
@@ -945,11 +982,12 @@ msgstr "Regelmäßige Berichte, KPIs"
 msgid "Report"
 msgstr "Bericht"
 
-#: src/pages/pricing.jsx:48
+#: src/pages/pricing.jsx:14
 msgid "Reporting"
 msgstr "Reporting"
 
-#: src/components/Feature.jsx:100 src/pages/features.jsx:80
+#: src/components/Feature.jsx:100
+#: src/pages/features.jsx:80
 msgid "Round & Exit Modeling"
 msgstr "Runden & Exit Modellierung"
 
@@ -957,7 +995,8 @@ msgstr "Runden & Exit Modellierung"
 msgid "Round Modeling"
 msgstr "Round Modeling"
 
-#: src/pages/features/modeling.jsx:20 src/pages/features/modeling.jsx:30
+#: src/pages/features/modeling.jsx:20
+#: src/pages/features/modeling.jsx:30
 msgid "Round and Exit Modeling"
 msgstr "Modellierung von Finanzierungsrunden und Exits"
 
@@ -981,7 +1020,7 @@ msgstr "Spare dir kostspielige Due-Diligence Tools"
 msgid "Save time in future due diligence by attaching legal documents to their transactions, making them searchable by the transaction information"
 msgstr "Spare Zeit bei zukünftigen Due-Diligence-Prüfungen, indem du an alle Transaktionen die relevanten rechtlichen Dokumente anhängst, welche später ganz einfach gefunden und aufgerufen werden können"
 
-#: src/pages/index.jsx:45
+#: src/pages/index.jsx:49
 msgid "Screenshot of the Ledgy app"
 msgstr "Screenshot der Ledgy-App"
 
@@ -994,8 +1033,10 @@ msgstr "Sicherer Datenraum"
 msgid "Secure data room, audit trail and read-only access for investors; save costly due diligence tools."
 msgstr "Sicherer Data Room, Audit-Trail und Lesezugriff für Investoren sparen dir teure Due-Diligence Tools"
 
-#: src/layouts/index.jsx:116 src/pages/privacy.jsx:109
-#: src/pages/security.jsx:25 src/pages/security.jsx:33
+#: src/layouts/index.jsx:121
+#: src/pages/privacy.jsx:109
+#: src/pages/security.jsx:25
+#: src/pages/security.jsx:33
 msgid "Security"
 msgstr "Sicherheit"
 
@@ -1039,7 +1080,7 @@ msgstr "Teile deine Szenarien als PDF, einschließlich Bewertungen, Investitione
 msgid "Show cap table fully diluted"
 msgstr "Fully-diluted Ansicht des Cap Tables"
 
-#: src/layouts/index.jsx:77
+#: src/layouts/index.jsx:81
 msgid "Sign up"
 msgstr ""
 
@@ -1055,8 +1096,10 @@ msgstr "Weltraumlift"
 msgid "Speed up your onboarding process with the bulk import feature"
 msgstr "Durch die Importtools kannst du innert kürzester Zeit loslegen"
 
-#: src/pages/features/captable.jsx:59 src/pages/features/captable.jsx:157
-#: src/pages/features/esop.jsx:54 src/pages/features/esop.jsx:152
+#: src/pages/features/captable.jsx:59
+#: src/pages/features/captable.jsx:157
+#: src/pages/features/esop.jsx:54
+#: src/pages/features/esop.jsx:152
 msgid "Spreadsheet importer"
 msgstr "Tabellenimport"
 
@@ -1084,11 +1127,11 @@ msgstr "Sichere Passwörter"
 msgid "Style your reports to your needs with the rich-text editor"
 msgstr "Gestalte Berichte nach deinen Bedürfnissen mit dem Rich-Text-Editor"
 
-#: src/components/SignupForm.jsx:52
+#: src/components/NewsletterForm.jsx:52
 msgid "Subscribe"
 msgstr ""
 
-#: src/layouts/index.jsx:90
+#: src/layouts/index.jsx:94
 msgid "Subscribe to the newsletter"
 msgstr ""
 
@@ -1104,7 +1147,8 @@ msgstr "Erfolgreiche Unternehmen teilen regelmäßig Updates mit ihren Stakehold
 msgid "Suggest changes"
 msgstr "Änderungen vorschlagen"
 
-#: src/pages/features/esop.jsx:36 src/pages/features/esop.jsx:74
+#: src/pages/features/esop.jsx:36
+#: src/pages/features/esop.jsx:74
 msgid "Supports everything"
 msgstr "Unterstützt alles"
 
@@ -1132,7 +1176,7 @@ msgstr "Team"
 msgid "Technical data"
 msgstr "Technische Daten"
 
-#: src/layouts/index.jsx:213
+#: src/layouts/index.jsx:217
 msgid "Terms of Service"
 msgstr "Nutzungsbedingungen"
 
@@ -1140,7 +1184,8 @@ msgstr "Nutzungsbedingungen"
 msgid "The Ledgy Blog"
 msgstr "Der Ledgy-Blog"
 
-#: src/layouts/index.jsx:380 src/pages/index.jsx:19
+#: src/layouts/index.jsx:385
+#: src/pages/index.jsx:19
 msgid "The New Standard in Equity Management"
 msgstr "Der Neue Standard des Equity Management"
 
@@ -1200,7 +1245,8 @@ msgstr "Behalte den Überblick über Ausübung, Kündigung und Verfall"
 msgid "Track your valuations and understand the history in terms of percentage and number of shares"
 msgstr "Verfolge die Unternehmensbewertung und verstehe die Historie in Bezug auf prozentuale und absolute Verteilung"
 
-#: src/pages/features/captable.jsx:41 src/pages/features/captable.jsx:76
+#: src/pages/features/captable.jsx:41
+#: src/pages/features/captable.jsx:76
 msgid "Transaction-based"
 msgstr "Transaktionsbasiert"
 
@@ -1220,15 +1266,12 @@ msgstr "Transparente Historie"
 msgid "Trust your Cap Table"
 msgstr "Vertraue deinem Cap Table"
 
-#: src/pages/pricing.jsx:152
+#: src/pages/pricing.jsx:146
 msgid "Try 30 days free"
 msgstr "30 Tage gratis testen"
 
-#: src/layouts/index.jsx:89
-msgid "Try Ledgy now for free"
-msgstr "Jetzt kostenlos ausprobieren"
-
-#: src/pages/pricing.jsx:81 src/pages/security.jsx:92
+#: src/pages/pricing.jsx:21
+#: src/pages/security.jsx:92
 msgid "Two-factor authentication"
 msgstr "2-Faktor-Authentisierung"
 
@@ -1256,23 +1299,23 @@ msgstr "Verstehe die Auswirkungen von Liquidationspräferenzen"
 msgid "Unforgeable proof that your documents were not modified since the certification"
 msgstr "Fälschungssicherer Nachweis, dass deine Dokumente seit der Zertifizierung nicht verändert wurden"
 
-#: src/pages/pricing.jsx:196
+#: src/pages/pricing.jsx:40
 msgid "Unlimited"
 msgstr "Unlimitiert"
 
-#: src/pages/pricing.jsx:190
+#: src/pages/pricing.jsx:39
 msgid "Unlimited admins"
 msgstr "Unlimitierte Admins"
 
-#: src/pages/pricing.jsx:184
+#: src/pages/pricing.jsx:38
 msgid "Unlimited rounds & scenarios"
 msgstr "Beliebige Runden & Szenarien"
 
-#: src/pages/pricing.jsx:68
+#: src/pages/pricing.jsx:17
 msgid "Up to 50 MB"
 msgstr "Bis zu 50 MB"
 
-#: src/pages/pricing.jsx:133
+#: src/pages/pricing.jsx:29
 msgid "Up to 500 MB"
 msgstr "Bis zu 500 MB"
 
@@ -1308,7 +1351,7 @@ msgstr "VAT-Nummer"
 msgid "Valuation"
 msgstr "Bewertung"
 
-#: src/pages/pricing.jsx:139
+#: src/pages/pricing.jsx:30
 msgid "Vesting, expiry, maturity"
 msgstr "Vesting, Verfall, Maturität"
 
@@ -1360,9 +1403,9 @@ msgstr "Bei der Rundenmodellierung zeigt der Cap Table die Verteilung danach"
 msgid "Yoko graduated from ETH and Oxford and was president of Swissloop, enabling the team to win the 3rd price at the SpaceX Hyperloop competition"
 msgstr "Yoko hat ihren Physik Master an der ETH und in Oxford gemacht und war Präsident von Swissloop, wo sie dem Team zum dritten Platz beim SpaceX Hyperloop Wettbewerb verholfen hat"
 
-#: src/pages/pricing.jsx:248
-msgid "You get a <0>20% discount</0> on Premium, if your startup provably reduces emissions.<1/><2>Write us</2> about your impact to see if you qualify."
-msgstr "Du bekommst <0>20% Discount</0> auf den Premium-Plan, wenn dein Startup nachweislich Emissionen reduziert.<1/><2>Schreib’ uns</2> über deinen Impact, um herauszufinden, ob das auf dein Startup zutrifft."
+#: src/pages/pricing.jsx:181
+msgid "You get a <0>20% discount</0> on Premium if your startup helps reducing carbon emissions.<1/><2>Write us</2> about your impact to see if you qualify."
+msgstr ""
 
 #: src/components/SecurityRow.jsx:31
 msgid "Your data is safe with us"
@@ -1380,17 +1423,13 @@ msgstr "und Aktiennummerierung wird nativ unterstützt"
 msgid "by liquidation preferences"
 msgstr "durch Liquidationspräferenzen"
 
-#: src/layouts/index.jsx:390
+#: src/layouts/index.jsx:394
 msgid "cap table, stock ledger, share register, startup, modeling, financing round, equity, esop, phantom, option plan, virtual, portfolio, reporting, investors"
 msgstr "Cap Table, Aktienbuch, Aktienregister, Startup, Modellierung, Finanzierungsrunde, Exit, ESOP, VSOP, Beteiligungsplan, Unternehmensbeteiligung, Mitarbeiterbeteiligung, Optionspläne, virtuelle Beteiligung, Reporting, Investor, Portfolio"
 
-#: src/layouts/index.jsx:94
+#: src/layouts/index.jsx:98
 msgid "for monthly updates on new features and start-up resources"
 msgstr ""
-
-#: src/pages/pricing.jsx:38
-msgid "free"
-msgstr "Gratis"
 
 #: src/pages/features/esop.jsx:37
 msgid "from options, to phantom and vested stock"
@@ -1408,11 +1447,12 @@ msgstr "helfen dir deinen Investoren gegenüber professionell aufzutreten"
 msgid "modeling a new round, including convertibles"
 msgstr "bei der Modellierung neuer Runden, einschließlich Wandeldarlehen"
 
-#: src/pages/pricing.jsx:104
+#: src/pages/pricing.jsx:147
 msgid "per stakeholder per month"
 msgstr "pro Stakeholder pro Monat"
 
-#: src/pages/features/captable.jsx:60 src/pages/features/esop.jsx:55
+#: src/pages/features/captable.jsx:60
+#: src/pages/features/esop.jsx:55
 msgid "save time and focus on what matters"
 msgstr "Spare Zeit und konzentriere dich auf Wichtiges"
 
@@ -1432,7 +1472,7 @@ msgstr "du kontrollierst, was andere sehen und bearbeiten können"
 msgid "stopping the spreadsheet mess"
 msgstr "stoppe das Durcheinander in Tabellendokumenten"
 
-#: src/pages/index.jsx:103
+#: src/pages/index.jsx:107
 msgid "that already use Ledgy for their equity management and investor relations"
 msgstr "die Ledgy bereits für ihre Beteiligungen und Investor Relations nutzen"
 
@@ -1464,6 +1504,6 @@ msgstr "bei der Planung deiner nächsten Finanzierungsrunde"
 msgid "with a single click"
 msgstr "mit einem einzigen Klick"
 
-#: src/pages/pricing.jsx:101
+#: src/pages/pricing.jsx:144
 msgid "€2"
 msgstr "€2"

--- a/src/locale/de/messages.po
+++ b/src/locale/de/messages.po
@@ -29,10 +29,6 @@ msgstr "30 Tage Probe"
 msgid "4 admins, view-only access"
 msgstr "4 Admins, Nur-Lese-Zugriff"
 
-#: src/components/SignupForm.jsx:18
-msgid "<0/> Signing up…"
-msgstr "<0/> Registrieren…"
-
 #: src/pages/features/collaboration.jsx:79
 msgid "<0>Admin</0> Full control over the company for your co-founders"
 msgstr "<0>Admin</0> Volle Kontrolle über das Unternehmen für dein Mitgründer"
@@ -231,7 +227,7 @@ msgstr "Optionen für die Massenerfassung"
 msgid "Calculates waterfall analysis of liquidation preferences across all rounds"
 msgstr "Berechnet die Wasserfallanalyse der Liquidationspräferenzen über alle Runden hinweg"
 
-#: src/layouts/index.jsx:184
+#: src/layouts/index.jsx:187
 msgid "Cap Table"
 msgstr "Cap Table"
 
@@ -247,7 +243,7 @@ msgstr "Cap Table während der Finanzierungsrundensimulation"
 msgid "Cap table management"
 msgstr "Cap Table-Verwaltung"
 
-#: src/layouts/index.jsx:122
+#: src/layouts/index.jsx:125
 msgid "Career"
 msgstr "Karriere"
 
@@ -264,7 +260,7 @@ msgstr "Timo programmiert seit seiner Schulzeit, wurde für die beste Masterarbe
 msgid "Collaboration & Due Diligence"
 msgstr "Zusammenarbeit & Due Diligence"
 
-#: src/layouts/index.jsx:105
+#: src/layouts/index.jsx:108
 msgid "Company"
 msgstr "Unternehmen"
 
@@ -285,7 +281,7 @@ msgstr "Umfassende Transaktionshistorie"
 msgid "Contact"
 msgstr "Kontakt"
 
-#: src/layouts/index.jsx:125
+#: src/layouts/index.jsx:128
 msgid "Contact & Imprint"
 msgstr "Kontakt & Impressum"
 
@@ -300,6 +296,10 @@ msgstr "Kontaktiere uns"
 #: src/pages/security.jsx:142
 msgid "Content-Security-Policy"
 msgstr "Content-Security-Policy"
+
+#: src/pages/subscribed.jsx:44
+msgid "Continue to site"
+msgstr ""
 
 #: src/pages/features/modeling.jsx:168
 msgid "Convert financing round"
@@ -317,7 +317,7 @@ msgstr "In Transaktionen umwandeln"
 msgid "Convertibles"
 msgstr "Wandeldarlehen"
 
-#: src/layouts/index.jsx:218
+#: src/layouts/index.jsx:221
 msgid "Cookie Policy"
 msgstr "Cookie-Richtlinie"
 
@@ -389,7 +389,7 @@ msgstr "Hilft dein Startup, die Klimakrise zu lösen?"
 msgid "Download holding confirmations with a single click"
 msgstr "Holdingbestätigungen mit einem einzigen Klick herunterladen"
 
-#: src/layouts/index.jsx:193
+#: src/layouts/index.jsx:196
 msgid "Due Diligence"
 msgstr "Due Diligence"
 
@@ -425,7 +425,7 @@ msgstr "Elektronische Signaturen<0/>"
 msgid "Email notification about upcoming vesting event"
 msgstr "E-Mail-Benachrichtigung über bevorstehende Vesting-Ereignisse"
 
-#: src/layouts/index.jsx:190
+#: src/layouts/index.jsx:193
 msgid "Employee Incentives"
 msgstr "Mitarbeiter​​​​beteiligungen"
 
@@ -446,7 +446,7 @@ msgstr "Motiviere deine Mitarbeiter"
 msgid "Enjoy the highest security standards"
 msgstr "Geniesse die höchsten Sicherheitsstandards"
 
-#: src/components/SignupForm.jsx:82
+#: src/components/SignupForm.jsx:43
 msgid "Enter your email…"
 msgstr "Gebe deine E-Mail-Adresse ein…"
 
@@ -486,7 +486,7 @@ msgstr "Jedes Unternehmen hat KPIs und Investoren lieben es, sie in Echtzeit zu 
 msgid "Exit modeling"
 msgstr "Exit-Modellierung"
 
-#: src/layouts/index.jsx:141
+#: src/layouts/index.jsx:144
 msgid "FAQ"
 msgstr "FAQ"
 
@@ -525,13 +525,9 @@ msgstr "Für noch mehr Sicherheit der Nutzerkonten. Übrigens, unsere Implementi
 msgid "Founder of Meisser Economics, Bitcoin Association Switzerland, and Wuala"
 msgstr "Gründer von Meisser Economics, Bitcoin Association Schweiz und Wuala"
 
-#: src/layouts/index.jsx:221
+#: src/layouts/index.jsx:224
 msgid "GDPR"
 msgstr "GDPR"
-
-#: src/components/SignupForm.jsx:22
-msgid "Get Started"
-msgstr "Los gehts"
 
 #: src/pages/index.jsx:40
 msgid "Get Started Free"
@@ -566,13 +562,17 @@ msgstr "Vermeide kostspielige Fehler"
 msgid "Get your cap table and employee participation plans right, from the beginning. Make your financing rounds a success and engage your investors and employees. Know your data is safe and compliant."
 msgstr "Erstelle deinen Cap Table und deine Mitarbeiterbeteiligungspläne von Anfang an richtig. Bringe deine Finanzierungsrunden zum Erfolg und motiviere deine Investoren und Mitarbeiter. Sei dir sicher, dass deine Daten gut aufgehoben sind."
 
-#: src/layouts/index.jsx:381
+#: src/layouts/index.jsx:384
 msgid "Get your cap table and employee participation plans right, from the beginning. Make your financing rounds a success and engage your investors and employees. Know your data is safe and compliant. Try now for free!"
 msgstr "Erstelle deinen Cap Table und Mitarbeiterbeteiligungspläne von Anfang an richtig. Bringe deine Finanzierungsrunden zum Erfolg und motiviere deine Investoren und Mitarbeiter. Sei unbesorgt, dass deine Daten sicher und konform sind. Jetzt kostenlos testen!"
 
-#: src/layouts/index.jsx:138
+#: src/layouts/index.jsx:141
 msgid "Getting Started"
 msgstr "Erste Schritte"
+
+#: src/pages/subscribed.jsx:47
+msgid "Go to Ledgy app"
+msgstr ""
 
 #: src/pages/features/esop.jsx:80
 msgid "Grant options, phantom options, warrants or add inverse vesting to stock transactions"
@@ -595,7 +595,7 @@ msgstr "HTTP-Header verhindern Cross-Site-Scripting und Code-Injection (<0>A+-Ra
 msgid "Healthcare & technology venture capital since 2001"
 msgstr "Healthcare & technology venture capital since 2001"
 
-#: src/layouts/index.jsx:133
+#: src/layouts/index.jsx:136
 msgid "Help"
 msgstr "Hilfe"
 
@@ -665,7 +665,7 @@ msgstr "Investor Relations & Portfolio"
 msgid "Investor portfolio"
 msgstr "Investoren-Portfolio"
 
-#: src/layouts/index.jsx:196
+#: src/layouts/index.jsx:199
 msgid "Investors"
 msgstr "Investor Relations"
 
@@ -713,7 +713,7 @@ msgstr "Key performance indicators"
 msgid "Kpi chart"
 msgstr "KPI-Diagramm"
 
-#: src/layouts/index.jsx:253
+#: src/layouts/index.jsx:256
 msgid "Language"
 msgstr "Sprache"
 
@@ -741,7 +741,7 @@ msgstr "Ledgy macht es einfach, eine Investition mit einer pro-rata Verteilung z
 msgid "Ledgy scales with your needs. Free for startups, powerful for grown-ups."
 msgstr "Ledgy skaliert mit deinen Anforderungen. Kostenlos für Startups, leistungsstark für größere Firmen."
 
-#: src/layouts/index.jsx:207
+#: src/layouts/index.jsx:210
 msgid "Legal"
 msgstr "Legal"
 
@@ -757,7 +757,7 @@ msgstr "Kontaktiere uns"
 msgid "Liquidation preferences"
 msgstr "Liquidationspräferenzen"
 
-#: src/layouts/index.jsx:73
+#: src/layouts/index.jsx:74
 msgid "Log In"
 msgstr "Anmelden"
 
@@ -785,7 +785,7 @@ msgstr "Marius hat sein Studium in Informatik an der Universität Mailand abgesc
 msgid "Meet the team behind Ledgy that went out to help startups thrive. Learn more about the people who trust in us."
 msgstr "Lerne das Team hinter Ledgy kennen, das sich zum Ziel gesetzt hat, Start-ups in ihrem Wachstum zu unterstützen. Erfahre mehr über die Menschen, die uns vertrauen."
 
-#: src/layouts/index.jsx:187
+#: src/layouts/index.jsx:190
 msgid "Modeling"
 msgstr "Modellierung"
 
@@ -796,10 +796,6 @@ msgstr "Mehrere Runden, 3 Szenarien"
 #: src/pages/privacy.jsx:84
 msgid "Name, email, address and any other details you provide. Provision of our services and management of your subscription. Providing you with updates about our services"
 msgstr "Name, E-Mail, Adresse und alle anderen Angaben, die du machst. Für die Bereitstellung unserer Dienstleistungen und Verwaltung deines Abonnements. Wir informieren dich über Neuigkeiten zu unseren Dienstleistungen"
-
-#: src/layouts/index.jsx:93
-msgid "No credit card required"
-msgstr "Du brauchst keine Kreditkarte anzugeben"
 
 #: src/pages/privacy.jsx:130
 msgid "Nobody has any access to the equity data you provide. They are safely stored at a secure data center in France. Your stakeholders have no access and don’t get emails before you explicitly invite them"
@@ -821,7 +817,7 @@ msgstr "Die Nummerierung wird auf Konsistenz geprüft, was dir die Gewissheit gi
 msgid "One of the most active Swiss early-stage angel investors"
 msgstr "Einer der aktivsten Schweizer Angel-Investoren für Early Stage"
 
-#: src/components/SignupForm.jsx:98
+#: src/components/SignupForm.jsx:56
 msgid "Oops. This email address is invalid."
 msgstr "Upsala. Diese E-Mail-Adresse ist leider ungültig."
 
@@ -884,7 +880,7 @@ msgstr "Prioritätssupport"
 msgid "Privacy"
 msgstr "Datenschutz"
 
-#: src/layouts/index.jsx:215
+#: src/layouts/index.jsx:218
 msgid "Privacy Policy"
 msgstr "Datenschutzrichtlinie"
 
@@ -900,7 +896,7 @@ msgstr "Datenschutz made in Europe. Weil deine Beteiligungsdaten nicht jeder ken
 msgid "Pro-rata distribution"
 msgstr "Pro-rata Verteilung"
 
-#: src/layouts/index.jsx:176
+#: src/layouts/index.jsx:179
 msgid "Product"
 msgstr "Produkt"
 
@@ -1043,10 +1039,6 @@ msgstr "Teile deine Szenarien als PDF, einschließlich Bewertungen, Investitione
 msgid "Show cap table fully diluted"
 msgstr "Fully-diluted Ansicht des Cap Tables"
 
-#: src/layouts/index.jsx:76
-msgid "Sign Up"
-msgstr "Registrieren"
-
 #: src/pages/features/modeling.jsx:120
 msgid "Simulation settings"
 msgstr "Simulationseinstellungen"
@@ -1088,6 +1080,19 @@ msgstr "Sichere Passwörter"
 msgid "Style your reports to your needs with the rich-text editor"
 msgstr "Gestalte Berichte nach deinen Bedürfnissen mit dem Rich-Text-Editor"
 
+#: src/components/SignupForm.jsx:52
+#: src/layouts/index.jsx:78
+msgid "Subscribe"
+msgstr ""
+
+#: src/layouts/index.jsx:92
+msgid "Subscribe to our newsletter"
+msgstr ""
+
+#: src/pages/subscribed.jsx:15
+msgid "Subscription confirmed"
+msgstr ""
+
 #: src/pages/features/investors.jsx:78
 msgid "Successful companies share regular updates with their stakeholders, holding themselves accountable"
 msgstr "Erfolgreiche Unternehmen teilen regelmäßig Updates mit ihren Stakeholdern"
@@ -1124,7 +1129,7 @@ msgstr "Team"
 msgid "Technical data"
 msgstr "Technische Daten"
 
-#: src/layouts/index.jsx:212
+#: src/layouts/index.jsx:215
 msgid "Terms of Service"
 msgstr "Nutzungsbedingungen"
 
@@ -1368,11 +1373,15 @@ msgstr "und Änderungprotokoll vereinfachen Due Diligence"
 msgid "and numbered shares are natively supported"
 msgstr "und Aktiennummerierung wird nativ unterstützt"
 
+#: src/layouts/index.jsx:96
+msgid "and stay up-to-date with everything your start-up needs"
+msgstr ""
+
 #: src/pages/features/modeling.jsx:60
 msgid "by liquidation preferences"
 msgstr "durch Liquidationspräferenzen"
 
-#: src/layouts/index.jsx:389
+#: src/layouts/index.jsx:392
 msgid "cap table, stock ledger, share register, startup, modeling, financing round, equity, esop, phantom, option plan, virtual, portfolio, reporting, investors"
 msgstr "Cap Table, Aktienbuch, Aktienregister, Startup, Modellierung, Finanzierungsrunde, Exit, ESOP, VSOP, Beteiligungsplan, Unternehmensbeteiligung, Mitarbeiterbeteiligung, Optionspläne, virtuelle Beteiligung, Reporting, Investor, Portfolio"
 

--- a/src/locale/de/messages.po
+++ b/src/locale/de/messages.po
@@ -49,12 +49,15 @@ msgstr "Für jedes Dokument wird beim Hochladen automatisch ein Zertifikat auf d
 msgid "A stakeholder is any holder of shares, (phantom) options, warrants, or convertibles.<0/>It does not include the company treasury or incentive pools."
 msgstr "Ein Stakeholder ist Halter von Anteilen, Optionen, Phantom-Anteilen, Warrants oder Wandeldarlehen.<0/>Die Firma selbst oder Beteiligungspools werden nicht eingerechnet."
 
-#: src/layouts/index.jsx:119 src/pages/about-us.jsx:17
+#: src/layouts/index.jsx:119
+#: src/pages/about-us.jsx:17
 #: src/pages/about-us.jsx:25
 msgid "About us"
 msgstr "Über uns"
 
-#: src/pages/pricing.jsx:20 src/pages/pricing.jsx:32 src/pages/pricing.jsx:43
+#: src/pages/pricing.jsx:20
+#: src/pages/pricing.jsx:32
+#: src/pages/pricing.jsx:43
 msgid "Access rights"
 msgstr "Zugriffsrechte"
 
@@ -86,7 +89,8 @@ msgstr "Vesting hinzufügen"
 msgid "Add vesting or inverse vesting to any transaction"
 msgstr "Hinzufügen von Vesting oder inversem Vesting zu jeder Transaktion"
 
-#: src/pages/features/modeling.jsx:53 src/pages/features/modeling.jsx:111
+#: src/pages/features/modeling.jsx:53
+#: src/pages/features/modeling.jsx:111
 msgid "Adjust your simulations"
 msgstr "Flexible Einstellungen"
 
@@ -102,7 +106,8 @@ msgstr "Alle Daten werden bei einem <0>unabhängigen Anbieter</0> in Frankreich 
 msgid "All standard features"
 msgstr "Alle Standard-Features"
 
-#: src/components/Feature.jsx:89 src/pages/features.jsx:23
+#: src/components/Feature.jsx:89
+#: src/pages/features.jsx:23
 msgid "All you need in one place"
 msgstr "Alles an einem Ort"
 
@@ -118,7 +123,8 @@ msgstr "Ein stets aktuelles Portfolio, von deinen Start-ups gepflegt"
 msgid "Analyze it by stakeholder, share class, stakeholder group and view it with all, outstanding or diluted shares"
 msgstr "Analysiere nach Stakeholder, Aktienklasse, Stakeholdergruppe, nur mit ausstehenden Anteilen oder verwässert"
 
-#: src/pages/features/esop.jsx:92 src/pages/pricing.jsx:30
+#: src/pages/features/esop.jsx:92
+#: src/pages/pricing.jsx:30
 msgid "Any vesting schedule"
 msgstr "Beliebiges Vesting"
 
@@ -142,7 +148,8 @@ msgstr "Wir bei Ledgy nehmen deine Sicherheit ernst. Sichere Passwörter, solide
 msgid "Attach doc to transaction"
 msgstr "Dokument an Transaktion anhängen"
 
-#: src/pages/features/captable.jsx:53 src/pages/features/captable.jsx:136
+#: src/pages/features/captable.jsx:53
+#: src/pages/features/captable.jsx:136
 msgid "Attach documents"
 msgstr "Dokumente anhängen"
 
@@ -194,7 +201,9 @@ msgstr "Blockchain-Zertifizierung"
 msgid "Blockchain notary"
 msgstr "Blockchain-Notar"
 
-#: src/layouts/index.jsx:65 src/layouts/index.jsx:122 src/layouts/index.jsx:162
+#: src/layouts/index.jsx:65
+#: src/layouts/index.jsx:122
+#: src/layouts/index.jsx:162
 #: src/pages/blog.jsx:61
 msgid "Blog"
 msgstr "Blog"
@@ -231,7 +240,8 @@ msgstr "Berechnet die Wasserfallanalyse der Liquidationspräferenzen über alle 
 msgid "Cap Table"
 msgstr "Cap Table"
 
-#: src/components/Feature.jsx:99 src/pages/features.jsx:58
+#: src/components/Feature.jsx:99
+#: src/pages/features.jsx:58
 msgid "Cap Table Management"
 msgstr "Cap Table Management"
 
@@ -255,7 +265,8 @@ msgstr "Wähle aus, ob nur Pools oder die Detailansicht mit den ausgegebenen Gra
 msgid "Coding since high school, Timo got an award for the best master thesis in computer science and worked one year as a computer engineer in robotics"
 msgstr "Timo programmiert seit seiner Schulzeit, wurde für die beste Masterarbeit in Computer Science ausgezeichnet und hat ein Jahr als Computer Engineer in der Robotik gearbeitet"
 
-#: src/components/Feature.jsx:101 src/pages/features/collaboration.jsx:20
+#: src/components/Feature.jsx:101
+#: src/pages/features/collaboration.jsx:20
 #: src/pages/features.jsx:104
 msgid "Collaboration & Due Diligence"
 msgstr "Zusammenarbeit & Due Diligence"
@@ -268,7 +279,8 @@ msgstr "Bald verfügbar"
 msgid "Company"
 msgstr "Unternehmen"
 
-#: src/pages/features/modeling.jsx:47 src/pages/features/modeling.jsx:95
+#: src/pages/features/modeling.jsx:47
+#: src/pages/features/modeling.jsx:95
 #: src/pages/features/modeling.jsx:105
 msgid "Compare and share scenarios"
 msgstr "Szenarien vergleichen und teilen"
@@ -281,7 +293,8 @@ msgstr "Vervollständige dein Portfolio"
 msgid "Comprehensive transaction history"
 msgstr "Umfassende Transaktionshistorie"
 
-#: src/pages/contact.jsx:10 src/pages/contact.jsx:74
+#: src/pages/contact.jsx:10
+#: src/pages/contact.jsx:74
 msgid "Contact"
 msgstr "Kontakt"
 
@@ -293,7 +306,8 @@ msgstr "Kontakt & Impressum"
 msgid "Contact data, usage statistics, and technical data"
 msgstr "Kontaktdaten, Nutzungsstatistiken und technische Daten"
 
-#: src/pages/pricing.jsx:156 src/pages/pricing.jsx:158
+#: src/pages/pricing.jsx:156
+#: src/pages/pricing.jsx:158
 msgid "Contact us"
 msgstr "Kontaktiere uns"
 
@@ -349,7 +363,8 @@ msgstr "Datenraum, Audit-Trail und schreibgeschützter Zugriff für Investoren e
 msgid "Digital entrepreneur and investor. Security, crypto & privacy expert"
 msgstr "Digital Entrepreneur und Investor. Security-, Crypto- & Privacy-Experte"
 
-#: src/pages/features/esop.jsx:137 src/pages/features/modeling.jsx:140
+#: src/pages/features/esop.jsx:137
+#: src/pages/features/modeling.jsx:140
 msgid "Diluted cap table"
 msgstr "Verwässerter Cap Table"
 
@@ -373,7 +388,9 @@ msgstr "Dokumentverknüpfungen"
 msgid "Document management"
 msgstr "Dokumenteverwaltung"
 
-#: src/pages/pricing.jsx:21 src/pages/pricing.jsx:33 src/pages/pricing.jsx:44
+#: src/pages/pricing.jsx:21
+#: src/pages/pricing.jsx:33
+#: src/pages/pricing.jsx:44
 msgid "Document storage"
 msgstr "Dokumentenablage"
 
@@ -429,7 +446,8 @@ msgstr "E-Mail-Benachrichtigung über bevorstehende Vesting-Ereignisse"
 msgid "Employee Incentives"
 msgstr "Mitarbeiter​​​​beteiligungen"
 
-#: src/components/Feature.jsx:98 src/pages/features/esop.jsx:25
+#: src/components/Feature.jsx:98
+#: src/pages/features/esop.jsx:25
 #: src/pages/features.jsx:33
 msgid "Employee Participation Plans"
 msgstr "Mitarbeiterbeteiligungspläne"
@@ -438,7 +456,8 @@ msgstr "Mitarbeiterbeteiligungspläne"
 msgid "Encrypted connection"
 msgstr "Verschlüsselte Verbindung"
 
-#: src/pages/features/esop.jsx:48 src/pages/features/esop.jsx:109
+#: src/pages/features/esop.jsx:48
+#: src/pages/features/esop.jsx:109
 msgid "Engage your employees"
 msgstr "Motiviere deine Mitarbeiter"
 
@@ -458,7 +477,8 @@ msgstr "Unternehmer, Business Angel, Gründer von Doodle.com"
 msgid "Entrepreneur, technologist, founder of Doodle.com"
 msgstr "Unternehmer, Technologe, Gründer von Doodle.com"
 
-#: src/pages/privacy.jsx:77 src/pages/privacy.jsx:129
+#: src/pages/privacy.jsx:77
+#: src/pages/privacy.jsx:129
 msgid "Equity data"
 msgstr "Aktiendaten"
 
@@ -478,7 +498,8 @@ msgstr "Europe’s symbiosis of early-stage VC funds and private investor networ
 msgid "Every company has KPIs, and investors love seeing them in real-time"
 msgstr "Jedes Unternehmen hat KPIs und Investoren lieben es, sie in Echtzeit zu verfolgen"
 
-#: src/pages/features/modeling.jsx:173 src/pages/features/modeling.jsx:186
+#: src/pages/features/modeling.jsx:173
+#: src/pages/features/modeling.jsx:186
 msgid "Exit modeling"
 msgstr "Exit-Modellierung"
 
@@ -486,10 +507,14 @@ msgstr "Exit-Modellierung"
 msgid "FAQ"
 msgstr "FAQ"
 
-#: src/layouts/index.jsx:59 src/layouts/index.jsx:190
-#: src/pages/features/captable.jsx:21 src/pages/features/collaboration.jsx:21
-#: src/pages/features/esop.jsx:16 src/pages/features/investors.jsx:21
-#: src/pages/features/modeling.jsx:21 src/pages/features.jsx:14
+#: src/layouts/index.jsx:59
+#: src/layouts/index.jsx:190
+#: src/pages/features/captable.jsx:21
+#: src/pages/features/collaboration.jsx:21
+#: src/pages/features/esop.jsx:16
+#: src/pages/features/investors.jsx:21
+#: src/pages/features/modeling.jsx:21
+#: src/pages/features.jsx:14
 msgid "Features"
 msgstr "Funktionen"
 
@@ -501,7 +526,9 @@ msgstr "Mit beliebig vielen Anteilsklassen, Treasury Anteilen, gepoolten Investi
 msgid "Finally, I have a reliable overview of all our shares, employee grants, and their legal documents. So much better than the Excel I used before."
 msgstr "Endlich habe ich eine zuverlässige Übersicht über all unsere Aktien, Mitarbeiterdarlehen und die rechtlichen Dokumente dazu. Das ist so viel besser als Excel, das ich früher benutzt habe."
 
-#: src/pages/pricing.jsx:19 src/pages/pricing.jsx:31 src/pages/pricing.jsx:42
+#: src/pages/pricing.jsx:19
+#: src/pages/pricing.jsx:31
+#: src/pages/pricing.jsx:42
 msgid "Financing round modeling"
 msgstr "Modellierung von Runden"
 
@@ -553,7 +580,8 @@ msgstr "Los geht’s"
 msgid "Get started in minutes with the copy-paste spreadsheet importer"
 msgstr "Lege in wenigen Minuten mit dem Copy-Paste-Tool für bestehende Tabellen los"
 
-#: src/pages/features/modeling.jsx:41 src/pages/features/modeling.jsx:76
+#: src/pages/features/modeling.jsx:41
+#: src/pages/features/modeling.jsx:76
 #: src/pages/features/modeling.jsx:88
 msgid "Get the calculations right"
 msgstr "Vermeide kostspielige Fehler"
@@ -604,7 +632,8 @@ msgid "Holding confirmation"
 msgstr "Besitzbestätigung"
 
 #: src/pages/features/collaboration.jsx:59
-#: src/pages/features/collaboration.jsx:169 src/pages/pricing.jsx:22
+#: src/pages/features/collaboration.jsx:169
+#: src/pages/pricing.jsx:22
 msgid "Holding confirmations"
 msgstr "Besitzbestätigungen"
 
@@ -652,8 +681,10 @@ msgstr "Intuitive, rechtsgültige und fehlerfreie Cap Tables von Anfang an, die 
 msgid "Investor & consultant (Farmy.ch, Flatfox.ch), founder of Students.ch"
 msgstr "Investor & Berater (Farmy.ch, Flatfox.ch), Gründer von Students.ch"
 
-#: src/components/Feature.jsx:102 src/pages/features/investors.jsx:20
-#: src/pages/features/investors.jsx:30 src/pages/features.jsx:126
+#: src/components/Feature.jsx:102
+#: src/pages/features/investors.jsx:20
+#: src/pages/features/investors.jsx:30
+#: src/pages/features.jsx:126
 msgid "Investor Relations & Portfolio"
 msgstr "Investor Relations & Portfolio"
 
@@ -845,7 +876,8 @@ msgstr "Experimentiere mit gründer- oder investorenfreundlichen Rahmenbedingung
 msgid "Pooled investment"
 msgstr "Gepoolte Investments"
 
-#: src/pages/features/captable.jsx:47 src/pages/features/captable.jsx:117
+#: src/pages/features/captable.jsx:47
+#: src/pages/features/captable.jsx:117
 #: src/pages/pricing.jsx:23
 msgid "Pooled investments"
 msgstr "Gepoolte Investments"
@@ -854,12 +886,15 @@ msgstr "Gepoolte Investments"
 msgid "Pooled investments are common in many countries, Ledgy helps you keep them organized"
 msgstr "Gepoolte Investitionen sind in vielen Ländern üblich. Ledgy hilft dir, sie zu organisieren"
 
-#: src/pages/features/investors.jsx:59 src/pages/features/investors.jsx:122
+#: src/pages/features/investors.jsx:59
+#: src/pages/features/investors.jsx:122
 #: src/pages/features/investors.jsx:128
 msgid "Portfolio history"
 msgstr "Portfolio-Historie"
 
-#: src/layouts/index.jsx:62 src/layouts/index.jsx:208 src/pages/pricing.jsx:121
+#: src/layouts/index.jsx:62
+#: src/layouts/index.jsx:208
+#: src/pages/pricing.jsx:121
 #: src/pages/pricing.jsx:130
 msgid "Pricing"
 msgstr "Preise"
@@ -868,7 +903,9 @@ msgstr "Preise"
 msgid "Priority support"
 msgstr "Prioritätssupport"
 
-#: src/layouts/index.jsx:128 src/pages/privacy.jsx:21 src/pages/privacy.jsx:29
+#: src/layouts/index.jsx:128
+#: src/pages/privacy.jsx:21
+#: src/pages/privacy.jsx:29
 msgid "Privacy"
 msgstr "Datenschutz"
 
@@ -880,7 +917,8 @@ msgstr "Datenschutzrichtlinie"
 msgid "Privacy made in Europe"
 msgstr "Datenschutz aus Europa"
 
-#: src/pages/privacy.jsx:22 src/pages/privacy.jsx:45
+#: src/pages/privacy.jsx:22
+#: src/pages/privacy.jsx:45
 msgid "Privacy made in Europe. Because your equity data is not for everyone."
 msgstr "Datenschutz made in Europe. Weil deine Beteiligungsdaten nicht jeder kennen sollte."
 
@@ -892,7 +930,8 @@ msgstr "Pro-rata Verteilung"
 msgid "Product"
 msgstr "Produkt"
 
-#: src/pages/features/investors.jsx:53 src/pages/features/investors.jsx:109
+#: src/pages/features/investors.jsx:53
+#: src/pages/features/investors.jsx:109
 msgid "Professional portfolio"
 msgstr "Professionelles Portfolio"
 
@@ -916,7 +955,8 @@ msgstr "Finde Dokumente anhand der verknüpften Transaktionen z.B. zu einer Pers
 msgid "Quickly pull up legal documents by the information of their linked transactions"
 msgstr "Finde Dokumente anhand der Informationen der verknüpften Transaktionen"
 
-#: src/components/SecurityRow.jsx:22 src/components/SecurityRow.jsx:37
+#: src/components/SecurityRow.jsx:22
+#: src/components/SecurityRow.jsx:37
 #: src/pages/blog.jsx:49
 msgid "Read more"
 msgstr "Mehr erfahren"
@@ -925,7 +965,8 @@ msgstr "Mehr erfahren"
 msgid "Record of edits"
 msgstr "Historie der Änderungen"
 
-#: src/pages/features/investors.jsx:41 src/pages/features/investors.jsx:76
+#: src/pages/features/investors.jsx:41
+#: src/pages/features/investors.jsx:76
 msgid "Recurring reports"
 msgstr "Regelmässige Reports"
 
@@ -941,7 +982,8 @@ msgstr "Bericht"
 msgid "Reporting"
 msgstr "Reporting"
 
-#: src/components/Feature.jsx:100 src/pages/features.jsx:80
+#: src/components/Feature.jsx:100
+#: src/pages/features.jsx:80
 msgid "Round & Exit Modeling"
 msgstr "Runden & Exit Modellierung"
 
@@ -949,7 +991,8 @@ msgstr "Runden & Exit Modellierung"
 msgid "Round Modeling"
 msgstr "Round Modeling"
 
-#: src/pages/features/modeling.jsx:20 src/pages/features/modeling.jsx:30
+#: src/pages/features/modeling.jsx:20
+#: src/pages/features/modeling.jsx:30
 msgid "Round and Exit Modeling"
 msgstr "Modellierung von Finanzierungsrunden und Exits"
 
@@ -986,8 +1029,10 @@ msgstr "Sicherer Datenraum"
 msgid "Secure data room, audit trail and read-only access for investors; save costly due diligence tools."
 msgstr "Sicherer Data Room, Audit-Trail und Lesezugriff für Investoren sparen dir teure Due-Diligence Tools."
 
-#: src/layouts/index.jsx:125 src/pages/privacy.jsx:109
-#: src/pages/security.jsx:25 src/pages/security.jsx:33
+#: src/layouts/index.jsx:125
+#: src/pages/privacy.jsx:109
+#: src/pages/security.jsx:25
+#: src/pages/security.jsx:33
 msgid "Security"
 msgstr "Sicherheit"
 
@@ -1047,8 +1092,10 @@ msgstr "Weltraumlift"
 msgid "Speed up your onboarding process with the bulk import feature"
 msgstr "Durch die Importtools kannst du innert kürzester Zeit loslegen"
 
-#: src/pages/features/captable.jsx:59 src/pages/features/captable.jsx:157
-#: src/pages/features/esop.jsx:54 src/pages/features/esop.jsx:152
+#: src/pages/features/captable.jsx:59
+#: src/pages/features/captable.jsx:157
+#: src/pages/features/esop.jsx:54
+#: src/pages/features/esop.jsx:152
 msgid "Spreadsheet importer"
 msgstr "Tabellenimport"
 
@@ -1092,7 +1139,8 @@ msgstr "Erfolgreiche Unternehmen teilen regelmäßig Updates mit ihren Stakehold
 msgid "Suggest changes"
 msgstr "Änderungen vorschlagen"
 
-#: src/pages/features/esop.jsx:36 src/pages/features/esop.jsx:74
+#: src/pages/features/esop.jsx:36
+#: src/pages/features/esop.jsx:74
 msgid "Supports everything"
 msgstr "Unterstützt alles"
 
@@ -1128,7 +1176,8 @@ msgstr "Nutzungsbedingungen"
 msgid "The Ledgy Blog"
 msgstr "Der Ledgy-Blog"
 
-#: src/layouts/index.jsx:389 src/pages/index.jsx:19
+#: src/layouts/index.jsx:389
+#: src/pages/index.jsx:19
 msgid "The New Standard in Equity Management"
 msgstr "Der Neue Standard des Equity Management"
 
@@ -1188,7 +1237,8 @@ msgstr "Behalte den Überblick über Ausübung, Kündigung und Verfall"
 msgid "Track your valuations and understand the history in terms of percentage and number of shares"
 msgstr "Verfolge die Unternehmensbewertung und verstehe die Historie in Bezug auf prozentuale und absolute Verteilung"
 
-#: src/pages/features/captable.jsx:41 src/pages/features/captable.jsx:76
+#: src/pages/features/captable.jsx:41
+#: src/pages/features/captable.jsx:76
 msgid "Transaction-based"
 msgstr "Transaktionsbasiert"
 
@@ -1212,7 +1262,8 @@ msgstr "Vertraue deinem Cap Table"
 msgid "Try 30 days free"
 msgstr "30 Tage gratis testen"
 
-#: src/pages/pricing.jsx:25 src/pages/security.jsx:92
+#: src/pages/pricing.jsx:25
+#: src/pages/security.jsx:92
 msgid "Two-factor authentication"
 msgstr "2-Faktor-Authentisierung"
 
@@ -1394,7 +1445,8 @@ msgstr "bei der Modellierung neuer Runden, einschließlich Wandeldarlehen"
 msgid "per stakeholder per month"
 msgstr "pro Stakeholder pro Monat"
 
-#: src/pages/features/captable.jsx:60 src/pages/features/esop.jsx:55
+#: src/pages/features/captable.jsx:60
+#: src/pages/features/esop.jsx:55
 msgid "save time and focus on what matters"
 msgstr "Spare Zeit und konzentriere dich auf Wichtiges"
 

--- a/src/locale/en/messages.po
+++ b/src/locale/en/messages.po
@@ -14,19 +14,19 @@ msgstr ""
 "Plural-Forms: \n"
 "MIME-Version: 1.0\n"
 
-#: src/pages/pricing.jsx:15
+#: src/pages/pricing.jsx:19
 msgid "1 round, 1 scenario"
 msgstr "1 round, 1 scenario"
 
-#: src/pages/pricing.jsx:16
+#: src/pages/pricing.jsx:20
 msgid "2 admins, stakeholder access"
 msgstr "2 admins, stakeholder access"
 
-#: src/pages/pricing.jsx:83
+#: src/pages/pricing.jsx:87
 msgid "30-day trial"
 msgstr "30-day trial"
 
-#: src/pages/pricing.jsx:28
+#: src/pages/pricing.jsx:32
 msgid "4 admins, view-only access"
 msgstr "4 admins, view-only access"
 
@@ -46,19 +46,19 @@ msgstr "<0>View</0> See all cap table info in a read-only mode for due diligence
 msgid "A certificate of each document is automatically stored on the bitcoin blockchain when uploading"
 msgstr "A certificate of each document is automatically stored on the bitcoin blockchain when uploading"
 
-#: src/pages/pricing.jsx:161
+#: src/pages/pricing.jsx:165
 msgid "A stakeholder is any holder of shares, (phantom) options, warrants, or convertibles.<0/>It does not include the company treasury or incentive pools."
 msgstr "A stakeholder is any holder of shares, (phantom) options, warrants, or convertibles.<0/>It does not include the company treasury or incentive pools."
 
-#: src/layouts/index.jsx:115
+#: src/layouts/index.jsx:119
 #: src/pages/about-us.jsx:17
 #: src/pages/about-us.jsx:25
 msgid "About us"
 msgstr "About us"
 
-#: src/pages/pricing.jsx:16
-#: src/pages/pricing.jsx:28
-#: src/pages/pricing.jsx:39
+#: src/pages/pricing.jsx:20
+#: src/pages/pricing.jsx:32
+#: src/pages/pricing.jsx:43
 msgid "Access rights"
 msgstr "Access rights"
 
@@ -95,7 +95,7 @@ msgstr "Add vesting or inverse vesting to any transaction"
 msgid "Adjust your simulations"
 msgstr "Adjust your simulations"
 
-#: src/pages/pricing.jsx:36
+#: src/pages/pricing.jsx:40
 msgid "All Premium features"
 msgstr "All Premium features"
 
@@ -103,7 +103,7 @@ msgstr "All Premium features"
 msgid "All data is stored at an <0>independent provider</0> in France"
 msgstr "All data is stored at an <0>independent provider</0> in France"
 
-#: src/pages/pricing.jsx:25
+#: src/pages/pricing.jsx:29
 msgid "All standard features"
 msgstr "All standard features"
 
@@ -125,7 +125,7 @@ msgid "Analyze it by stakeholder, share class, stakeholder group and view it wit
 msgstr "Analyze it by stakeholder, share class, stakeholder group and view it with all, outstanding or diluted shares"
 
 #: src/pages/features/esop.jsx:92
-#: src/pages/pricing.jsx:26
+#: src/pages/pricing.jsx:30
 msgid "Any vesting schedule"
 msgstr "Any vesting schedule"
 
@@ -203,13 +203,13 @@ msgid "Blockchain notary"
 msgstr "Blockchain notary"
 
 #: src/layouts/index.jsx:65
-#: src/layouts/index.jsx:118
-#: src/layouts/index.jsx:158
+#: src/layouts/index.jsx:122
+#: src/layouts/index.jsx:162
 #: src/pages/blog.jsx:61
 msgid "Blog"
 msgstr "Blog"
 
-#: src/pages/pricing.jsx:32
+#: src/pages/pricing.jsx:36
 msgid "Breakpoint & exit analyses"
 msgstr "Breakpoint & exit analyses"
 
@@ -237,7 +237,7 @@ msgstr "Bulk entry options"
 msgid "Calculates waterfall analysis of liquidation preferences across all rounds"
 msgstr "Calculates waterfall analysis of liquidation preferences across all rounds"
 
-#: src/layouts/index.jsx:189
+#: src/layouts/index.jsx:193
 msgid "Cap Table"
 msgstr "Cap Table"
 
@@ -250,11 +250,11 @@ msgstr "Cap Table Management"
 msgid "Cap table during round modeling"
 msgstr "Cap table during round modeling"
 
-#: src/pages/pricing.jsx:13
+#: src/pages/pricing.jsx:17
 msgid "Cap table management"
 msgstr "Cap table management"
 
-#: src/layouts/index.jsx:127
+#: src/layouts/index.jsx:131
 msgid "Career"
 msgstr "Career"
 
@@ -272,7 +272,11 @@ msgstr "Coding since high school, Timo got an award for the best master thesis i
 msgid "Collaboration & Due Diligence"
 msgstr "Collaboration & Due Diligence"
 
-#: src/layouts/index.jsx:110
+#: src/pages/pricing.jsx:12
+msgid "Coming soon"
+msgstr "Coming soon"
+
+#: src/layouts/index.jsx:114
 msgid "Company"
 msgstr "Company"
 
@@ -295,7 +299,7 @@ msgstr "Comprehensive transaction history"
 msgid "Contact"
 msgstr "Contact"
 
-#: src/layouts/index.jsx:130
+#: src/layouts/index.jsx:134
 msgid "Contact & Imprint"
 msgstr "Contact & Imprint"
 
@@ -303,18 +307,14 @@ msgstr "Contact & Imprint"
 msgid "Contact data, usage statistics, and technical data"
 msgstr "Contact data, usage statistics, and technical data"
 
-#: src/pages/pricing.jsx:152
-#: src/pages/pricing.jsx:154
+#: src/pages/pricing.jsx:156
+#: src/pages/pricing.jsx:158
 msgid "Contact us"
 msgstr "Contact us"
 
 #: src/pages/security.jsx:142
 msgid "Content-Security-Policy"
 msgstr "Content-Security-Policy"
-
-#: src/pages/subscribed.jsx:40
-msgid "Continue exploring"
-msgstr "Continue exploring"
 
 #: src/pages/features/modeling.jsx:168
 msgid "Convert financing round"
@@ -328,11 +328,11 @@ msgstr "Convert the final scenario in just two clicks"
 msgid "Convert to transactions"
 msgstr "Convert to transactions"
 
-#: src/pages/pricing.jsx:20
+#: src/pages/pricing.jsx:24
 msgid "Convertibles"
 msgstr "Convertibles"
 
-#: src/layouts/index.jsx:223
+#: src/layouts/index.jsx:227
 msgid "Cookie Policy"
 msgstr "Cookie Policy"
 
@@ -369,7 +369,7 @@ msgstr "Digital entrepreneur and investor. Security, crypto & privacy expert"
 msgid "Diluted cap table"
 msgstr "Diluted cap table"
 
-#: src/pages/pricing.jsx:169
+#: src/pages/pricing.jsx:173
 msgid "Discover all features"
 msgstr "Discover all features"
 
@@ -389,17 +389,17 @@ msgstr "Document links"
 msgid "Document management"
 msgstr "Document management"
 
-#: src/pages/pricing.jsx:17
-#: src/pages/pricing.jsx:29
-#: src/pages/pricing.jsx:40
+#: src/pages/pricing.jsx:21
+#: src/pages/pricing.jsx:33
+#: src/pages/pricing.jsx:44
 msgid "Document storage"
 msgstr "Document storage"
 
-#: src/pages/pricing.jsx:43
+#: src/pages/pricing.jsx:47
 msgid "Document workflow <0/>"
 msgstr "Document workflow <0/>"
 
-#: src/pages/pricing.jsx:175
+#: src/pages/pricing.jsx:179
 msgid "Does your startup tackle the climate crisis?"
 msgstr "Does your startup tackle the climate crisis?"
 
@@ -407,7 +407,7 @@ msgstr "Does your startup tackle the climate crisis?"
 msgid "Download holding confirmations with a single click"
 msgstr "Download holding confirmations with a single click"
 
-#: src/layouts/index.jsx:198
+#: src/layouts/index.jsx:202
 msgid "Due Diligence"
 msgstr "Due Diligence"
 
@@ -435,7 +435,7 @@ msgstr "EU data protection"
 msgid "Edit log"
 msgstr "Edit log"
 
-#: src/pages/pricing.jsx:49
+#: src/pages/pricing.jsx:53
 msgid "Electronic signatures <0/>"
 msgstr "Electronic signatures <0/>"
 
@@ -443,7 +443,7 @@ msgstr "Electronic signatures <0/>"
 msgid "Email notification about upcoming vesting event"
 msgstr "Email notification about upcoming vesting event"
 
-#: src/layouts/index.jsx:195
+#: src/layouts/index.jsx:199
 msgid "Employee Incentives"
 msgstr "Employee Incentives"
 
@@ -466,7 +466,7 @@ msgstr "Engage your employees"
 msgid "Enjoy the highest security standards"
 msgstr "Enjoy the highest security standards"
 
-#: src/components/NewsletterForm.jsx:43
+#: src/components/NewsletterForm.jsx:47
 msgid "Enter your email…"
 msgstr "Enter your email…"
 
@@ -487,7 +487,7 @@ msgstr "Equity data"
 msgid "Equity data is too important to be accidentally tweaked in a spreadsheet"
 msgstr "Equity data is too important to be accidentally tweaked in a spreadsheet"
 
-#: src/pages/pricing.jsx:26
+#: src/pages/pricing.jsx:30
 msgid "Equity plan management"
 msgstr "Equity plan management"
 
@@ -504,12 +504,12 @@ msgstr "Every company has KPIs, and investors love seeing them in real-time"
 msgid "Exit modeling"
 msgstr "Exit modeling"
 
-#: src/layouts/index.jsx:146
+#: src/layouts/index.jsx:150
 msgid "FAQ"
 msgstr "FAQ"
 
 #: src/layouts/index.jsx:59
-#: src/layouts/index.jsx:186
+#: src/layouts/index.jsx:190
 #: src/pages/features/captable.jsx:21
 #: src/pages/features/collaboration.jsx:21
 #: src/pages/features/esop.jsx:16
@@ -527,9 +527,9 @@ msgstr "Featuring unlimited share classes, treasury shares, pooled investments, 
 msgid "Finally, I have a reliable overview of all our shares, employee grants, and their legal documents. So much better than the Excel I used before."
 msgstr "Finally, I have a reliable overview of all our shares, employee grants, and their legal documents. So much better than the Excel I used before."
 
-#: src/pages/pricing.jsx:15
-#: src/pages/pricing.jsx:27
-#: src/pages/pricing.jsx:38
+#: src/pages/pricing.jsx:19
+#: src/pages/pricing.jsx:31
+#: src/pages/pricing.jsx:42
 msgid "Financing round modeling"
 msgstr "Financing round modeling"
 
@@ -549,11 +549,11 @@ msgstr "For even better protection of accounts. And our implementation is <0>ope
 msgid "Founder of Meisser Economics, Bitcoin Association Switzerland, and Wuala"
 msgstr "Founder of Meisser Economics, Bitcoin Association Switzerland, and Wuala"
 
-#: src/pages/pricing.jsx:138
+#: src/pages/pricing.jsx:142
 msgid "Free"
 msgstr "Free"
 
-#: src/layouts/index.jsx:226
+#: src/layouts/index.jsx:230
 msgid "GDPR"
 msgstr "GDPR"
 
@@ -573,7 +573,7 @@ msgstr "Get notified of important vesting and expiry events and engage your empl
 msgid "Get notified two weeks before a cliff or vesting ends or a grant expires to not miss using your participation plan for engaging your employees"
 msgstr "Get notified two weeks before a cliff or vesting ends or a grant expires to not miss using your participation plan for engaging your employees"
 
-#: src/pages/pricing.jsx:140
+#: src/pages/pricing.jsx:144
 msgid "Get started"
 msgstr "Get started"
 
@@ -591,17 +591,13 @@ msgstr "Get the calculations right"
 msgid "Get your cap table and employee participation plans right, from the beginning. Make your financing rounds a success and engage your investors and employees. Know your data is safe and compliant."
 msgstr "Get your cap table and employee participation plans right, from the beginning. Make your financing rounds a success and engage your investors and employees. Know your data is safe and compliant."
 
-#: src/layouts/index.jsx:386
+#: src/layouts/index.jsx:390
 msgid "Get your cap table and employee participation plans right, from the beginning. Make your financing rounds a success and engage your investors and employees. Know your data is safe and compliant. Try now for free!"
 msgstr "Get your cap table and employee participation plans right, from the beginning. Make your financing rounds a success and engage your investors and employees. Know your data is safe and compliant. Try now for free!"
 
-#: src/layouts/index.jsx:143
+#: src/layouts/index.jsx:147
 msgid "Getting Started"
 msgstr "Getting Started"
-
-#: src/pages/subscribed.jsx:43
-msgid "Go to Ledgy app"
-msgstr "Go to Ledgy app"
 
 #: src/pages/features/esop.jsx:80
 msgid "Grant options, phantom options, warrants or add inverse vesting to stock transactions"
@@ -624,7 +620,7 @@ msgstr "HTTP headers prevent cross-site scripting and code injection (<0>A+ rati
 msgid "Healthcare & technology venture capital since 2001"
 msgstr "Healthcare & technology venture capital since 2001"
 
-#: src/layouts/index.jsx:138
+#: src/layouts/index.jsx:142
 msgid "Help"
 msgstr "Help"
 
@@ -638,7 +634,7 @@ msgstr "Holding confirmation"
 
 #: src/pages/features/collaboration.jsx:59
 #: src/pages/features/collaboration.jsx:169
-#: src/pages/pricing.jsx:18
+#: src/pages/pricing.jsx:22
 msgid "Holding confirmations"
 msgstr "Holding confirmations"
 
@@ -697,7 +693,7 @@ msgstr "Investor Relations & Portfolio"
 msgid "Investor portfolio"
 msgstr "Investor portfolio"
 
-#: src/layouts/index.jsx:201
+#: src/layouts/index.jsx:205
 msgid "Investors"
 msgstr "Investors"
 
@@ -745,7 +741,7 @@ msgstr "Key performance indicators"
 msgid "Kpi chart"
 msgstr "Kpi chart"
 
-#: src/layouts/index.jsx:258
+#: src/layouts/index.jsx:262
 msgid "Language"
 msgstr "Language"
 
@@ -769,11 +765,11 @@ msgstr "Learn more about document management"
 msgid "Ledgy makes it easy to simulate an investment with a pro-rata distribution"
 msgstr "Ledgy makes it easy to simulate an investment with a pro-rata distribution"
 
-#: src/pages/pricing.jsx:118
+#: src/pages/pricing.jsx:122
 msgid "Ledgy scales with your needs. Free for startups, powerful for grown-ups."
 msgstr "Ledgy scales with your needs. Free for startups, powerful for grown-ups."
 
-#: src/layouts/index.jsx:212
+#: src/layouts/index.jsx:216
 msgid "Legal"
 msgstr "Legal"
 
@@ -785,11 +781,11 @@ msgstr "Legal documents associated with the transactions at your fingertips"
 msgid "Let’s Get In Touch"
 msgstr "Let’s Get In Touch"
 
-#: src/pages/pricing.jsx:31
+#: src/pages/pricing.jsx:35
 msgid "Liquidation preferences"
 msgstr "Liquidation preferences"
 
-#: src/layouts/index.jsx:74
+#: src/layouts/index.jsx:78
 msgid "Log In"
 msgstr "Log In"
 
@@ -817,11 +813,11 @@ msgstr "Marius has a background in computer science, graduated from Milan Univer
 msgid "Meet the team behind Ledgy that went out to help startups thrive. Learn more about the people who trust in us."
 msgstr "Meet the team behind Ledgy that went out to help startups thrive. Learn more about the people who trust in us."
 
-#: src/layouts/index.jsx:192
+#: src/layouts/index.jsx:196
 msgid "Modeling"
 msgstr "Modeling"
 
-#: src/pages/pricing.jsx:27
+#: src/pages/pricing.jsx:31
 msgid "Multiple rounds, 3 scenarios"
 msgstr "Multiple rounds, 3 scenarios"
 
@@ -833,7 +829,7 @@ msgstr "Name, email, address and any other details you provide. Provision of our
 msgid "Nobody has any access to the equity data you provide. They are safely stored at a secure data center in France. Your stakeholders have no access and don’t get emails before you explicitly invite them"
 msgstr "Nobody has any access to the equity data you provide. They are safely stored at a secure data center in France. Your stakeholders have no access and don’t get emails before you explicitly invite them"
 
-#: src/pages/pricing.jsx:30
+#: src/pages/pricing.jsx:34
 msgid "Notifications"
 msgstr "Notifications"
 
@@ -849,7 +845,7 @@ msgstr "Numbers are checked for consistency, giving you the peace of mind that n
 msgid "One of the most active Swiss early-stage angel investors"
 msgstr "One of the most active Swiss early-stage angel investors"
 
-#: src/components/NewsletterForm.jsx:56
+#: src/components/NewsletterForm.jsx:60
 msgid "Oops. This email address is invalid."
 msgstr "Oops. This email address is invalid."
 
@@ -869,7 +865,7 @@ msgstr "Password encryption"
 msgid "Peer-reviewed code"
 msgstr "Peer-reviewed code"
 
-#: src/pages/pricing.jsx:37
+#: src/pages/pricing.jsx:41
 msgid "Phone & chat, onboarding"
 msgstr "Phone & chat, onboarding"
 
@@ -883,7 +879,7 @@ msgstr "Pooled investment"
 
 #: src/pages/features/captable.jsx:47
 #: src/pages/features/captable.jsx:117
-#: src/pages/pricing.jsx:19
+#: src/pages/pricing.jsx:23
 msgid "Pooled investments"
 msgstr "Pooled investments"
 
@@ -898,23 +894,23 @@ msgid "Portfolio history"
 msgstr "Portfolio history"
 
 #: src/layouts/index.jsx:62
-#: src/layouts/index.jsx:204
-#: src/pages/pricing.jsx:117
-#: src/pages/pricing.jsx:126
+#: src/layouts/index.jsx:208
+#: src/pages/pricing.jsx:121
+#: src/pages/pricing.jsx:130
 msgid "Pricing"
 msgstr "Pricing"
 
-#: src/pages/pricing.jsx:37
+#: src/pages/pricing.jsx:41
 msgid "Priority support"
 msgstr "Priority support"
 
-#: src/layouts/index.jsx:124
+#: src/layouts/index.jsx:128
 #: src/pages/privacy.jsx:21
 #: src/pages/privacy.jsx:29
 msgid "Privacy"
 msgstr "Privacy"
 
-#: src/layouts/index.jsx:220
+#: src/layouts/index.jsx:224
 msgid "Privacy Policy"
 msgstr "Privacy Policy"
 
@@ -931,7 +927,7 @@ msgstr "Privacy made in Europe. Because your equity data is not for everyone."
 msgid "Pro-rata distribution"
 msgstr "Pro-rata distribution"
 
-#: src/layouts/index.jsx:181
+#: src/layouts/index.jsx:185
 msgid "Product"
 msgstr "Product"
 
@@ -975,7 +971,7 @@ msgstr "Record of edits"
 msgid "Recurring reports"
 msgstr "Recurring reports"
 
-#: src/pages/pricing.jsx:14
+#: src/pages/pricing.jsx:18
 msgid "Recurring reports, KPIs"
 msgstr "Recurring reports, KPIs"
 
@@ -983,7 +979,7 @@ msgstr "Recurring reports, KPIs"
 msgid "Report"
 msgstr "Report"
 
-#: src/pages/pricing.jsx:14
+#: src/pages/pricing.jsx:18
 msgid "Reporting"
 msgstr "Reporting"
 
@@ -1034,7 +1030,7 @@ msgstr "Secure data room"
 msgid "Secure data room, audit trail and read-only access for investors; save costly due diligence tools."
 msgstr "Secure data room, audit trail and read-only access for investors; save costly due diligence tools."
 
-#: src/layouts/index.jsx:121
+#: src/layouts/index.jsx:125
 #: src/pages/privacy.jsx:109
 #: src/pages/security.jsx:25
 #: src/pages/security.jsx:33
@@ -1081,7 +1077,7 @@ msgstr "Share your scenarios as pdf, including valuations, investments, converti
 msgid "Show cap table fully diluted"
 msgstr "Show cap table fully diluted"
 
-#: src/layouts/index.jsx:81
+#: src/layouts/index.jsx:85
 msgid "Sign up"
 msgstr "Sign up"
 
@@ -1128,17 +1124,13 @@ msgstr "Strong passwords"
 msgid "Style your reports to your needs with the rich-text editor"
 msgstr "Style your reports to your needs with the rich-text editor"
 
-#: src/components/NewsletterForm.jsx:52
+#: src/components/NewsletterForm.jsx:56
 msgid "Subscribe"
 msgstr "Subscribe"
 
-#: src/layouts/index.jsx:94
+#: src/layouts/index.jsx:98
 msgid "Subscribe to the newsletter"
 msgstr "Subscribe to the newsletter"
-
-#: src/pages/subscribed.jsx:15
-msgid "Subscription confirmed"
-msgstr "Subscription confirmed"
 
 #: src/pages/features/investors.jsx:78
 msgid "Successful companies share regular updates with their stakeholders, holding themselves accountable"
@@ -1177,7 +1169,7 @@ msgstr "Team"
 msgid "Technical data"
 msgstr "Technical data"
 
-#: src/layouts/index.jsx:217
+#: src/layouts/index.jsx:221
 msgid "Terms of Service"
 msgstr "Terms of Service"
 
@@ -1185,7 +1177,7 @@ msgstr "Terms of Service"
 msgid "The Ledgy Blog"
 msgstr "The Ledgy Blog"
 
-#: src/layouts/index.jsx:385
+#: src/layouts/index.jsx:389
 #: src/pages/index.jsx:19
 msgid "The New Standard in Equity Management"
 msgstr "The New Standard in Equity Management"
@@ -1267,11 +1259,11 @@ msgstr "Transparent history"
 msgid "Trust your Cap Table"
 msgstr "Trust your Cap Table"
 
-#: src/pages/pricing.jsx:146
+#: src/pages/pricing.jsx:150
 msgid "Try 30 days free"
 msgstr "Try 30 days free"
 
-#: src/pages/pricing.jsx:21
+#: src/pages/pricing.jsx:25
 #: src/pages/security.jsx:92
 msgid "Two-factor authentication"
 msgstr "Two-factor authentication"
@@ -1300,23 +1292,23 @@ msgstr "Understand the impact of liquidation preferences"
 msgid "Unforgeable proof that your documents were not modified since the certification"
 msgstr "Unforgeable proof that your documents were not modified since the certification"
 
-#: src/pages/pricing.jsx:40
+#: src/pages/pricing.jsx:44
 msgid "Unlimited"
 msgstr "Unlimited"
 
-#: src/pages/pricing.jsx:39
+#: src/pages/pricing.jsx:43
 msgid "Unlimited admins"
 msgstr "Unlimited admins"
 
-#: src/pages/pricing.jsx:38
+#: src/pages/pricing.jsx:42
 msgid "Unlimited rounds & scenarios"
 msgstr "Unlimited rounds & scenarios"
 
-#: src/pages/pricing.jsx:17
+#: src/pages/pricing.jsx:21
 msgid "Up to 50 MB"
 msgstr "Up to 50 MB"
 
-#: src/pages/pricing.jsx:29
+#: src/pages/pricing.jsx:33
 msgid "Up to 500 MB"
 msgstr "Up to 500 MB"
 
@@ -1352,7 +1344,7 @@ msgstr "VAT number"
 msgid "Valuation"
 msgstr "Valuation"
 
-#: src/pages/pricing.jsx:30
+#: src/pages/pricing.jsx:34
 msgid "Vesting, expiry, maturity"
 msgstr "Vesting, expiry, maturity"
 
@@ -1404,7 +1396,7 @@ msgstr "When in round modeling, the cap table below shows the distribution after
 msgid "Yoko graduated from ETH and Oxford and was president of Swissloop, enabling the team to win the 3rd price at the SpaceX Hyperloop competition"
 msgstr "Yoko graduated from ETH and Oxford and was president of Swissloop, enabling the team to win the 3rd price at the SpaceX Hyperloop competition"
 
-#: src/pages/pricing.jsx:181
+#: src/pages/pricing.jsx:185
 msgid "You get a <0>20% discount</0> on Premium if your startup helps reducing carbon emissions.<1/><2>Write us</2> about your impact to see if you qualify."
 msgstr "You get a <0>20% discount</0> on Premium if your startup helps reducing carbon emissions.<1/><2>Write us</2> about your impact to see if you qualify."
 
@@ -1424,11 +1416,11 @@ msgstr "and numbered shares are natively supported"
 msgid "by liquidation preferences"
 msgstr "by liquidation preferences"
 
-#: src/layouts/index.jsx:394
+#: src/layouts/index.jsx:398
 msgid "cap table, stock ledger, share register, startup, modeling, financing round, equity, esop, phantom, option plan, virtual, portfolio, reporting, investors"
 msgstr "cap table, stock ledger, share register, startup, modeling, financing round, equity, esop, phantom, option plan, virtual, portfolio, reporting, investors"
 
-#: src/layouts/index.jsx:98
+#: src/layouts/index.jsx:102
 msgid "for monthly updates on new features and start-up resources"
 msgstr "for monthly updates on new features and start-up resources"
 
@@ -1448,7 +1440,7 @@ msgstr "help you be professional towards your investors"
 msgid "modeling a new round, including convertibles"
 msgstr "modeling a new round, including convertibles"
 
-#: src/pages/pricing.jsx:147
+#: src/pages/pricing.jsx:151
 msgid "per stakeholder per month"
 msgstr "per stakeholder per month"
 
@@ -1505,6 +1497,6 @@ msgstr "when planning your next financing round"
 msgid "with a single click"
 msgstr "with a single click"
 
-#: src/pages/pricing.jsx:144
+#: src/pages/pricing.jsx:148
 msgid "€2"
 msgstr "€2"

--- a/src/locale/en/messages.po
+++ b/src/locale/en/messages.po
@@ -14,19 +14,19 @@ msgstr ""
 "Plural-Forms: \n"
 "MIME-Version: 1.0\n"
 
-#: src/pages/pricing.jsx:56
+#: src/pages/pricing.jsx:15
 msgid "1 round, 1 scenario"
 msgstr "1 round, 1 scenario"
 
-#: src/pages/pricing.jsx:62
+#: src/pages/pricing.jsx:16
 msgid "2 admins, stakeholder access"
 msgstr "2 admins, stakeholder access"
 
-#: src/pages/pricing.jsx:95
-msgid "30 days trial"
-msgstr "30 days trial"
+#: src/pages/pricing.jsx:83
+msgid "30-day trial"
+msgstr "30-day trial"
 
-#: src/pages/pricing.jsx:127
+#: src/pages/pricing.jsx:28
 msgid "4 admins, view-only access"
 msgstr "4 admins, view-only access"
 
@@ -46,19 +46,19 @@ msgstr "<0>View</0> See all cap table info in a read-only mode for due diligence
 msgid "A certificate of each document is automatically stored on the bitcoin blockchain when uploading"
 msgstr "A certificate of each document is automatically stored on the bitcoin blockchain when uploading"
 
-#: src/pages/pricing.jsx:228
+#: src/pages/pricing.jsx:161
 msgid "A stakeholder is any holder of shares, (phantom) options, warrants, or convertibles.<0/>It does not include the company treasury or incentive pools."
 msgstr "A stakeholder is any holder of shares, (phantom) options, warrants, or convertibles.<0/>It does not include the company treasury or incentive pools."
 
-#: src/layouts/index.jsx:111
+#: src/layouts/index.jsx:115
 #: src/pages/about-us.jsx:17
 #: src/pages/about-us.jsx:25
 msgid "About us"
 msgstr "About us"
 
-#: src/pages/pricing.jsx:60
-#: src/pages/pricing.jsx:125
-#: src/pages/pricing.jsx:188
+#: src/pages/pricing.jsx:16
+#: src/pages/pricing.jsx:28
+#: src/pages/pricing.jsx:39
 msgid "Access rights"
 msgstr "Access rights"
 
@@ -95,17 +95,17 @@ msgstr "Add vesting or inverse vesting to any transaction"
 msgid "Adjust your simulations"
 msgstr "Adjust your simulations"
 
-#: src/pages/pricing.jsx:172
+#: src/pages/pricing.jsx:36
 msgid "All Premium features"
 msgstr "All Premium features"
-
-#: src/pages/pricing.jsx:109
-msgid "All Standard features"
-msgstr "All Standard features"
 
 #: src/pages/security.jsx:184
 msgid "All data is stored at an <0>independent provider</0> in France"
 msgstr "All data is stored at an <0>independent provider</0> in France"
+
+#: src/pages/pricing.jsx:25
+msgid "All standard features"
+msgstr "All standard features"
 
 #: src/components/Feature.jsx:89
 #: src/pages/features.jsx:23
@@ -125,7 +125,7 @@ msgid "Analyze it by stakeholder, share class, stakeholder group and view it wit
 msgstr "Analyze it by stakeholder, share class, stakeholder group and view it with all, outstanding or diluted shares"
 
 #: src/pages/features/esop.jsx:92
-#: src/pages/pricing.jsx:115
+#: src/pages/pricing.jsx:26
 msgid "Any vesting schedule"
 msgstr "Any vesting schedule"
 
@@ -203,13 +203,13 @@ msgid "Blockchain notary"
 msgstr "Blockchain notary"
 
 #: src/layouts/index.jsx:65
-#: src/layouts/index.jsx:114
-#: src/layouts/index.jsx:154
+#: src/layouts/index.jsx:118
+#: src/layouts/index.jsx:158
 #: src/pages/blog.jsx:61
 msgid "Blog"
 msgstr "Blog"
 
-#: src/pages/pricing.jsx:146
+#: src/pages/pricing.jsx:32
 msgid "Breakpoint & exit analyses"
 msgstr "Breakpoint & exit analyses"
 
@@ -237,7 +237,7 @@ msgstr "Bulk entry options"
 msgid "Calculates waterfall analysis of liquidation preferences across all rounds"
 msgstr "Calculates waterfall analysis of liquidation preferences across all rounds"
 
-#: src/layouts/index.jsx:185
+#: src/layouts/index.jsx:189
 msgid "Cap Table"
 msgstr "Cap Table"
 
@@ -250,11 +250,11 @@ msgstr "Cap Table Management"
 msgid "Cap table during round modeling"
 msgstr "Cap table during round modeling"
 
-#: src/pages/pricing.jsx:44
+#: src/pages/pricing.jsx:13
 msgid "Cap table management"
 msgstr "Cap table management"
 
-#: src/layouts/index.jsx:123
+#: src/layouts/index.jsx:127
 msgid "Career"
 msgstr "Career"
 
@@ -272,7 +272,7 @@ msgstr "Coding since high school, Timo got an award for the best master thesis i
 msgid "Collaboration & Due Diligence"
 msgstr "Collaboration & Due Diligence"
 
-#: src/layouts/index.jsx:106
+#: src/layouts/index.jsx:110
 msgid "Company"
 msgstr "Company"
 
@@ -295,7 +295,7 @@ msgstr "Comprehensive transaction history"
 msgid "Contact"
 msgstr "Contact"
 
-#: src/layouts/index.jsx:126
+#: src/layouts/index.jsx:130
 msgid "Contact & Imprint"
 msgstr "Contact & Imprint"
 
@@ -303,8 +303,8 @@ msgstr "Contact & Imprint"
 msgid "Contact data, usage statistics, and technical data"
 msgstr "Contact data, usage statistics, and technical data"
 
-#: src/pages/pricing.jsx:165
-#: src/pages/pricing.jsx:219
+#: src/pages/pricing.jsx:152
+#: src/pages/pricing.jsx:154
 msgid "Contact us"
 msgstr "Contact us"
 
@@ -328,11 +328,11 @@ msgstr "Convert the final scenario in just two clicks"
 msgid "Convert to transactions"
 msgstr "Convert to transactions"
 
-#: src/pages/pricing.jsx:78
+#: src/pages/pricing.jsx:20
 msgid "Convertibles"
 msgstr "Convertibles"
 
-#: src/layouts/index.jsx:219
+#: src/layouts/index.jsx:223
 msgid "Cookie Policy"
 msgstr "Cookie Policy"
 
@@ -369,7 +369,7 @@ msgstr "Digital entrepreneur and investor. Security, crypto & privacy expert"
 msgid "Diluted cap table"
 msgstr "Diluted cap table"
 
-#: src/pages/pricing.jsx:236
+#: src/pages/pricing.jsx:169
 msgid "Discover all features"
 msgstr "Discover all features"
 
@@ -389,17 +389,17 @@ msgstr "Document links"
 msgid "Document management"
 msgstr "Document management"
 
-#: src/pages/pricing.jsx:66
-#: src/pages/pricing.jsx:131
-#: src/pages/pricing.jsx:194
+#: src/pages/pricing.jsx:17
+#: src/pages/pricing.jsx:29
+#: src/pages/pricing.jsx:40
 msgid "Document storage"
 msgstr "Document storage"
 
-#: src/pages/pricing.jsx:200
-msgid "Document workflows<0/>"
-msgstr "Document workflows<0/>"
+#: src/pages/pricing.jsx:43
+msgid "Document workflow <0/>"
+msgstr "Document workflow <0/>"
 
-#: src/pages/pricing.jsx:242
+#: src/pages/pricing.jsx:175
 msgid "Does your startup tackle the climate crisis?"
 msgstr "Does your startup tackle the climate crisis?"
 
@@ -407,7 +407,7 @@ msgstr "Does your startup tackle the climate crisis?"
 msgid "Download holding confirmations with a single click"
 msgstr "Download holding confirmations with a single click"
 
-#: src/layouts/index.jsx:194
+#: src/layouts/index.jsx:198
 msgid "Due Diligence"
 msgstr "Due Diligence"
 
@@ -435,15 +435,15 @@ msgstr "EU data protection"
 msgid "Edit log"
 msgstr "Edit log"
 
-#: src/pages/pricing.jsx:206
-msgid "Electronic signatures<0/>"
-msgstr "Electronic signatures<0/>"
+#: src/pages/pricing.jsx:49
+msgid "Electronic signatures <0/>"
+msgstr "Electronic signatures <0/>"
 
 #: src/pages/features/esop.jsx:123
 msgid "Email notification about upcoming vesting event"
 msgstr "Email notification about upcoming vesting event"
 
-#: src/layouts/index.jsx:191
+#: src/layouts/index.jsx:195
 msgid "Employee Incentives"
 msgstr "Employee Incentives"
 
@@ -466,13 +466,9 @@ msgstr "Engage your employees"
 msgid "Enjoy the highest security standards"
 msgstr "Enjoy the highest security standards"
 
-#: src/components/SignupForm.jsx:43
+#: src/components/NewsletterForm.jsx:43
 msgid "Enter your email…"
 msgstr "Enter your email…"
-
-#: src/pages/pricing.jsx:161
-msgid "Enterprise"
-msgstr "Enterprise"
 
 #: src/pages/about-us.jsx:169
 msgid "Entrepreneur, business angel, founder of Doodle.com"
@@ -491,7 +487,7 @@ msgstr "Equity data"
 msgid "Equity data is too important to be accidentally tweaked in a spreadsheet"
 msgstr "Equity data is too important to be accidentally tweaked in a spreadsheet"
 
-#: src/pages/pricing.jsx:113
+#: src/pages/pricing.jsx:26
 msgid "Equity plan management"
 msgstr "Equity plan management"
 
@@ -508,12 +504,12 @@ msgstr "Every company has KPIs, and investors love seeing them in real-time"
 msgid "Exit modeling"
 msgstr "Exit modeling"
 
-#: src/layouts/index.jsx:142
+#: src/layouts/index.jsx:146
 msgid "FAQ"
 msgstr "FAQ"
 
 #: src/layouts/index.jsx:59
-#: src/layouts/index.jsx:182
+#: src/layouts/index.jsx:186
 #: src/pages/features/captable.jsx:21
 #: src/pages/features/collaboration.jsx:21
 #: src/pages/features/esop.jsx:16
@@ -527,17 +523,17 @@ msgstr "Features"
 msgid "Featuring unlimited share classes, treasury shares, pooled investments, and automatic share numbering"
 msgstr "Featuring unlimited share classes, treasury shares, pooled investments, and automatic share numbering"
 
-#: src/pages/index.jsx:137
+#: src/pages/index.jsx:141
 msgid "Finally, I have a reliable overview of all our shares, employee grants, and their legal documents. So much better than the Excel I used before."
 msgstr "Finally, I have a reliable overview of all our shares, employee grants, and their legal documents. So much better than the Excel I used before."
 
-#: src/pages/pricing.jsx:54
-#: src/pages/pricing.jsx:119
-#: src/pages/pricing.jsx:182
+#: src/pages/pricing.jsx:15
+#: src/pages/pricing.jsx:27
+#: src/pages/pricing.jsx:38
 msgid "Financing round modeling"
 msgstr "Financing round modeling"
 
-#: src/pages/index.jsx:151
+#: src/pages/index.jsx:155
 msgid "Find out why they trust us"
 msgstr "Find out why they trust us"
 
@@ -553,11 +549,15 @@ msgstr "For even better protection of accounts. And our implementation is <0>ope
 msgid "Founder of Meisser Economics, Bitcoin Association Switzerland, and Wuala"
 msgstr "Founder of Meisser Economics, Bitcoin Association Switzerland, and Wuala"
 
-#: src/layouts/index.jsx:222
+#: src/pages/pricing.jsx:138
+msgid "Free"
+msgstr "Free"
+
+#: src/layouts/index.jsx:226
 msgid "GDPR"
 msgstr "GDPR"
 
-#: src/pages/index.jsx:40
+#: src/pages/index.jsx:44
 msgid "Get Started Free"
 msgstr "Get Started Free"
 
@@ -573,7 +573,7 @@ msgstr "Get notified of important vesting and expiry events and engage your empl
 msgid "Get notified two weeks before a cliff or vesting ends or a grant expires to not miss using your participation plan for engaging your employees"
 msgstr "Get notified two weeks before a cliff or vesting ends or a grant expires to not miss using your participation plan for engaging your employees"
 
-#: src/pages/pricing.jsx:86
+#: src/pages/pricing.jsx:140
 msgid "Get started"
 msgstr "Get started"
 
@@ -591,11 +591,11 @@ msgstr "Get the calculations right"
 msgid "Get your cap table and employee participation plans right, from the beginning. Make your financing rounds a success and engage your investors and employees. Know your data is safe and compliant."
 msgstr "Get your cap table and employee participation plans right, from the beginning. Make your financing rounds a success and engage your investors and employees. Know your data is safe and compliant."
 
-#: src/layouts/index.jsx:382
+#: src/layouts/index.jsx:386
 msgid "Get your cap table and employee participation plans right, from the beginning. Make your financing rounds a success and engage your investors and employees. Know your data is safe and compliant. Try now for free!"
 msgstr "Get your cap table and employee participation plans right, from the beginning. Make your financing rounds a success and engage your investors and employees. Know your data is safe and compliant. Try now for free!"
 
-#: src/layouts/index.jsx:139
+#: src/layouts/index.jsx:143
 msgid "Getting Started"
 msgstr "Getting Started"
 
@@ -624,7 +624,7 @@ msgstr "HTTP headers prevent cross-site scripting and code injection (<0>A+ rati
 msgid "Healthcare & technology venture capital since 2001"
 msgstr "Healthcare & technology venture capital since 2001"
 
-#: src/layouts/index.jsx:134
+#: src/layouts/index.jsx:138
 msgid "Help"
 msgstr "Help"
 
@@ -638,7 +638,7 @@ msgstr "Holding confirmation"
 
 #: src/pages/features/collaboration.jsx:59
 #: src/pages/features/collaboration.jsx:169
-#: src/pages/pricing.jsx:72
+#: src/pages/pricing.jsx:18
 msgid "Holding confirmations"
 msgstr "Holding confirmations"
 
@@ -646,7 +646,7 @@ msgstr "Holding confirmations"
 msgid "How we protect your information"
 msgstr "How we protect your information"
 
-#: src/pages/index.jsx:126
+#: src/pages/index.jsx:130
 msgid "I needed exactly that. Every founder should use Ledgy’s modeling tools for financing rounds!"
 msgstr "I needed exactly that. Every founder should use Ledgy’s modeling tools for financing rounds!"
 
@@ -697,7 +697,7 @@ msgstr "Investor Relations & Portfolio"
 msgid "Investor portfolio"
 msgstr "Investor portfolio"
 
-#: src/layouts/index.jsx:197
+#: src/layouts/index.jsx:201
 msgid "Investors"
 msgstr "Investors"
 
@@ -709,7 +709,7 @@ msgstr "Invite the founder or CFO to claim the company and keep the information 
 msgid "Invite your employees to track their stake and vesting in their Ledgy portfolio"
 msgstr "Invite your employees to track their stake and vesting in their Ledgy portfolio"
 
-#: src/pages/index.jsx:100
+#: src/pages/index.jsx:104
 msgid "Join hundreds of companies"
 msgstr "Join hundreds of companies"
 
@@ -745,7 +745,7 @@ msgstr "Key performance indicators"
 msgid "Kpi chart"
 msgstr "Kpi chart"
 
-#: src/layouts/index.jsx:254
+#: src/layouts/index.jsx:258
 msgid "Language"
 msgstr "Language"
 
@@ -769,11 +769,11 @@ msgstr "Learn more about document management"
 msgid "Ledgy makes it easy to simulate an investment with a pro-rata distribution"
 msgstr "Ledgy makes it easy to simulate an investment with a pro-rata distribution"
 
-#: src/pages/pricing.jsx:16
+#: src/pages/pricing.jsx:118
 msgid "Ledgy scales with your needs. Free for startups, powerful for grown-ups."
 msgstr "Ledgy scales with your needs. Free for startups, powerful for grown-ups."
 
-#: src/layouts/index.jsx:208
+#: src/layouts/index.jsx:212
 msgid "Legal"
 msgstr "Legal"
 
@@ -785,7 +785,7 @@ msgstr "Legal documents associated with the transactions at your fingertips"
 msgid "Let’s Get In Touch"
 msgstr "Let’s Get In Touch"
 
-#: src/pages/pricing.jsx:143
+#: src/pages/pricing.jsx:31
 msgid "Liquidation preferences"
 msgstr "Liquidation preferences"
 
@@ -817,11 +817,11 @@ msgstr "Marius has a background in computer science, graduated from Milan Univer
 msgid "Meet the team behind Ledgy that went out to help startups thrive. Learn more about the people who trust in us."
 msgstr "Meet the team behind Ledgy that went out to help startups thrive. Learn more about the people who trust in us."
 
-#: src/layouts/index.jsx:188
+#: src/layouts/index.jsx:192
 msgid "Modeling"
 msgstr "Modeling"
 
-#: src/pages/pricing.jsx:121
+#: src/pages/pricing.jsx:27
 msgid "Multiple rounds, 3 scenarios"
 msgstr "Multiple rounds, 3 scenarios"
 
@@ -833,7 +833,7 @@ msgstr "Name, email, address and any other details you provide. Provision of our
 msgid "Nobody has any access to the equity data you provide. They are safely stored at a secure data center in France. Your stakeholders have no access and don’t get emails before you explicitly invite them"
 msgstr "Nobody has any access to the equity data you provide. They are safely stored at a secure data center in France. Your stakeholders have no access and don’t get emails before you explicitly invite them"
 
-#: src/pages/pricing.jsx:137
+#: src/pages/pricing.jsx:30
 msgid "Notifications"
 msgstr "Notifications"
 
@@ -849,7 +849,7 @@ msgstr "Numbers are checked for consistency, giving you the peace of mind that n
 msgid "One of the most active Swiss early-stage angel investors"
 msgstr "One of the most active Swiss early-stage angel investors"
 
-#: src/components/SignupForm.jsx:56
+#: src/components/NewsletterForm.jsx:56
 msgid "Oops. This email address is invalid."
 msgstr "Oops. This email address is invalid."
 
@@ -869,7 +869,7 @@ msgstr "Password encryption"
 msgid "Peer-reviewed code"
 msgstr "Peer-reviewed code"
 
-#: src/pages/pricing.jsx:178
+#: src/pages/pricing.jsx:37
 msgid "Phone & chat, onboarding"
 msgstr "Phone & chat, onboarding"
 
@@ -883,7 +883,7 @@ msgstr "Pooled investment"
 
 #: src/pages/features/captable.jsx:47
 #: src/pages/features/captable.jsx:117
-#: src/pages/pricing.jsx:75
+#: src/pages/pricing.jsx:19
 msgid "Pooled investments"
 msgstr "Pooled investments"
 
@@ -897,28 +897,24 @@ msgstr "Pooled investments are common in many countries, Ledgy helps you keep th
 msgid "Portfolio history"
 msgstr "Portfolio history"
 
-#: src/pages/pricing.jsx:98
-msgid "Premium"
-msgstr "Premium"
-
 #: src/layouts/index.jsx:62
-#: src/layouts/index.jsx:200
-#: src/pages/pricing.jsx:15
-#: src/pages/pricing.jsx:24
+#: src/layouts/index.jsx:204
+#: src/pages/pricing.jsx:117
+#: src/pages/pricing.jsx:126
 msgid "Pricing"
 msgstr "Pricing"
 
-#: src/pages/pricing.jsx:176
+#: src/pages/pricing.jsx:37
 msgid "Priority support"
 msgstr "Priority support"
 
-#: src/layouts/index.jsx:120
+#: src/layouts/index.jsx:124
 #: src/pages/privacy.jsx:21
 #: src/pages/privacy.jsx:29
 msgid "Privacy"
 msgstr "Privacy"
 
-#: src/layouts/index.jsx:216
+#: src/layouts/index.jsx:220
 msgid "Privacy Policy"
 msgstr "Privacy Policy"
 
@@ -935,7 +931,7 @@ msgstr "Privacy made in Europe. Because your equity data is not for everyone."
 msgid "Pro-rata distribution"
 msgstr "Pro-rata distribution"
 
-#: src/layouts/index.jsx:177
+#: src/layouts/index.jsx:181
 msgid "Product"
 msgstr "Product"
 
@@ -979,7 +975,7 @@ msgstr "Record of edits"
 msgid "Recurring reports"
 msgstr "Recurring reports"
 
-#: src/pages/pricing.jsx:50
+#: src/pages/pricing.jsx:14
 msgid "Recurring reports, KPIs"
 msgstr "Recurring reports, KPIs"
 
@@ -987,7 +983,7 @@ msgstr "Recurring reports, KPIs"
 msgid "Report"
 msgstr "Report"
 
-#: src/pages/pricing.jsx:48
+#: src/pages/pricing.jsx:14
 msgid "Reporting"
 msgstr "Reporting"
 
@@ -1025,7 +1021,7 @@ msgstr "Save on costly due diligence tools"
 msgid "Save time in future due diligence by attaching legal documents to their transactions, making them searchable by the transaction information"
 msgstr "Save time in future due diligence by attaching legal documents to their transactions, making them searchable by the transaction information"
 
-#: src/pages/index.jsx:45
+#: src/pages/index.jsx:49
 msgid "Screenshot of the Ledgy app"
 msgstr "Screenshot of the Ledgy app"
 
@@ -1038,7 +1034,7 @@ msgstr "Secure data room"
 msgid "Secure data room, audit trail and read-only access for investors; save costly due diligence tools."
 msgstr "Secure data room, audit trail and read-only access for investors; save costly due diligence tools."
 
-#: src/layouts/index.jsx:117
+#: src/layouts/index.jsx:121
 #: src/pages/privacy.jsx:109
 #: src/pages/security.jsx:25
 #: src/pages/security.jsx:33
@@ -1085,7 +1081,7 @@ msgstr "Share your scenarios as pdf, including valuations, investments, converti
 msgid "Show cap table fully diluted"
 msgstr "Show cap table fully diluted"
 
-#: src/layouts/index.jsx:77
+#: src/layouts/index.jsx:81
 msgid "Sign up"
 msgstr "Sign up"
 
@@ -1132,11 +1128,11 @@ msgstr "Strong passwords"
 msgid "Style your reports to your needs with the rich-text editor"
 msgstr "Style your reports to your needs with the rich-text editor"
 
-#: src/components/SignupForm.jsx:52
+#: src/components/NewsletterForm.jsx:52
 msgid "Subscribe"
 msgstr "Subscribe"
 
-#: src/layouts/index.jsx:90
+#: src/layouts/index.jsx:94
 msgid "Subscribe to the newsletter"
 msgstr "Subscribe to the newsletter"
 
@@ -1181,7 +1177,7 @@ msgstr "Team"
 msgid "Technical data"
 msgstr "Technical data"
 
-#: src/layouts/index.jsx:213
+#: src/layouts/index.jsx:217
 msgid "Terms of Service"
 msgstr "Terms of Service"
 
@@ -1189,7 +1185,7 @@ msgstr "Terms of Service"
 msgid "The Ledgy Blog"
 msgstr "The Ledgy Blog"
 
-#: src/layouts/index.jsx:381
+#: src/layouts/index.jsx:385
 #: src/pages/index.jsx:19
 msgid "The New Standard in Equity Management"
 msgstr "The New Standard in Equity Management"
@@ -1271,11 +1267,11 @@ msgstr "Transparent history"
 msgid "Trust your Cap Table"
 msgstr "Trust your Cap Table"
 
-#: src/pages/pricing.jsx:152
+#: src/pages/pricing.jsx:146
 msgid "Try 30 days free"
 msgstr "Try 30 days free"
 
-#: src/pages/pricing.jsx:81
+#: src/pages/pricing.jsx:21
 #: src/pages/security.jsx:92
 msgid "Two-factor authentication"
 msgstr "Two-factor authentication"
@@ -1304,23 +1300,23 @@ msgstr "Understand the impact of liquidation preferences"
 msgid "Unforgeable proof that your documents were not modified since the certification"
 msgstr "Unforgeable proof that your documents were not modified since the certification"
 
-#: src/pages/pricing.jsx:196
+#: src/pages/pricing.jsx:40
 msgid "Unlimited"
 msgstr "Unlimited"
 
-#: src/pages/pricing.jsx:190
+#: src/pages/pricing.jsx:39
 msgid "Unlimited admins"
 msgstr "Unlimited admins"
 
-#: src/pages/pricing.jsx:184
+#: src/pages/pricing.jsx:38
 msgid "Unlimited rounds & scenarios"
 msgstr "Unlimited rounds & scenarios"
 
-#: src/pages/pricing.jsx:68
+#: src/pages/pricing.jsx:17
 msgid "Up to 50 MB"
 msgstr "Up to 50 MB"
 
-#: src/pages/pricing.jsx:133
+#: src/pages/pricing.jsx:29
 msgid "Up to 500 MB"
 msgstr "Up to 500 MB"
 
@@ -1356,7 +1352,7 @@ msgstr "VAT number"
 msgid "Valuation"
 msgstr "Valuation"
 
-#: src/pages/pricing.jsx:139
+#: src/pages/pricing.jsx:30
 msgid "Vesting, expiry, maturity"
 msgstr "Vesting, expiry, maturity"
 
@@ -1408,9 +1404,9 @@ msgstr "When in round modeling, the cap table below shows the distribution after
 msgid "Yoko graduated from ETH and Oxford and was president of Swissloop, enabling the team to win the 3rd price at the SpaceX Hyperloop competition"
 msgstr "Yoko graduated from ETH and Oxford and was president of Swissloop, enabling the team to win the 3rd price at the SpaceX Hyperloop competition"
 
-#: src/pages/pricing.jsx:248
-msgid "You get a <0>20% discount</0> on Premium, if your startup provably reduces emissions.<1/><2>Write us</2> about your impact to see if you qualify."
-msgstr "You get a <0>20% discount</0> on Premium, if your startup provably reduces emissions.<1/><2>Write us</2> about your impact to see if you qualify."
+#: src/pages/pricing.jsx:181
+msgid "You get a <0>20% discount</0> on Premium if your startup helps reducing carbon emissions.<1/><2>Write us</2> about your impact to see if you qualify."
+msgstr "You get a <0>20% discount</0> on Premium if your startup helps reducing carbon emissions.<1/><2>Write us</2> about your impact to see if you qualify."
 
 #: src/components/SecurityRow.jsx:31
 msgid "Your data is safe with us"
@@ -1428,17 +1424,13 @@ msgstr "and numbered shares are natively supported"
 msgid "by liquidation preferences"
 msgstr "by liquidation preferences"
 
-#: src/layouts/index.jsx:390
+#: src/layouts/index.jsx:394
 msgid "cap table, stock ledger, share register, startup, modeling, financing round, equity, esop, phantom, option plan, virtual, portfolio, reporting, investors"
 msgstr "cap table, stock ledger, share register, startup, modeling, financing round, equity, esop, phantom, option plan, virtual, portfolio, reporting, investors"
 
-#: src/layouts/index.jsx:94
+#: src/layouts/index.jsx:98
 msgid "for monthly updates on new features and start-up resources"
 msgstr "for monthly updates on new features and start-up resources"
-
-#: src/pages/pricing.jsx:38
-msgid "free"
-msgstr "free"
 
 #: src/pages/features/esop.jsx:37
 msgid "from options, to phantom and vested stock"
@@ -1456,7 +1448,7 @@ msgstr "help you be professional towards your investors"
 msgid "modeling a new round, including convertibles"
 msgstr "modeling a new round, including convertibles"
 
-#: src/pages/pricing.jsx:104
+#: src/pages/pricing.jsx:147
 msgid "per stakeholder per month"
 msgstr "per stakeholder per month"
 
@@ -1481,7 +1473,7 @@ msgstr "so you control what others can see and do"
 msgid "stopping the spreadsheet mess"
 msgstr "stopping the spreadsheet mess"
 
-#: src/pages/index.jsx:103
+#: src/pages/index.jsx:107
 msgid "that already use Ledgy for their equity management and investor relations"
 msgstr "that already use Ledgy for their equity management and investor relations"
 
@@ -1513,6 +1505,6 @@ msgstr "when planning your next financing round"
 msgid "with a single click"
 msgstr "with a single click"
 
-#: src/pages/pricing.jsx:101
+#: src/pages/pricing.jsx:144
 msgid "€2"
 msgstr "€2"

--- a/src/locale/en/messages.po
+++ b/src/locale/en/messages.po
@@ -50,7 +50,7 @@ msgstr "A certificate of each document is automatically stored on the bitcoin bl
 msgid "A stakeholder is any holder of shares, (phantom) options, warrants, or convertibles.<0/>It does not include the company treasury or incentive pools."
 msgstr "A stakeholder is any holder of shares, (phantom) options, warrants, or convertibles.<0/>It does not include the company treasury or incentive pools."
 
-#: src/layouts/index.jsx:113
+#: src/layouts/index.jsx:111
 #: src/pages/about-us.jsx:17
 #: src/pages/about-us.jsx:25
 msgid "About us"
@@ -203,8 +203,8 @@ msgid "Blockchain notary"
 msgstr "Blockchain notary"
 
 #: src/layouts/index.jsx:65
-#: src/layouts/index.jsx:116
-#: src/layouts/index.jsx:156
+#: src/layouts/index.jsx:114
+#: src/layouts/index.jsx:154
 #: src/pages/blog.jsx:61
 msgid "Blog"
 msgstr "Blog"
@@ -237,7 +237,7 @@ msgstr "Bulk entry options"
 msgid "Calculates waterfall analysis of liquidation preferences across all rounds"
 msgstr "Calculates waterfall analysis of liquidation preferences across all rounds"
 
-#: src/layouts/index.jsx:187
+#: src/layouts/index.jsx:185
 msgid "Cap Table"
 msgstr "Cap Table"
 
@@ -254,7 +254,7 @@ msgstr "Cap table during round modeling"
 msgid "Cap table management"
 msgstr "Cap table management"
 
-#: src/layouts/index.jsx:125
+#: src/layouts/index.jsx:123
 msgid "Career"
 msgstr "Career"
 
@@ -272,7 +272,7 @@ msgstr "Coding since high school, Timo got an award for the best master thesis i
 msgid "Collaboration & Due Diligence"
 msgstr "Collaboration & Due Diligence"
 
-#: src/layouts/index.jsx:108
+#: src/layouts/index.jsx:106
 msgid "Company"
 msgstr "Company"
 
@@ -295,7 +295,7 @@ msgstr "Comprehensive transaction history"
 msgid "Contact"
 msgstr "Contact"
 
-#: src/layouts/index.jsx:128
+#: src/layouts/index.jsx:126
 msgid "Contact & Imprint"
 msgstr "Contact & Imprint"
 
@@ -312,9 +312,9 @@ msgstr "Contact us"
 msgid "Content-Security-Policy"
 msgstr "Content-Security-Policy"
 
-#: src/pages/subscribed.jsx:44
-msgid "Continue to site"
-msgstr "Continue to site"
+#: src/pages/subscribed.jsx:40
+msgid "Continue exploring"
+msgstr "Continue exploring"
 
 #: src/pages/features/modeling.jsx:168
 msgid "Convert financing round"
@@ -332,7 +332,7 @@ msgstr "Convert to transactions"
 msgid "Convertibles"
 msgstr "Convertibles"
 
-#: src/layouts/index.jsx:221
+#: src/layouts/index.jsx:219
 msgid "Cookie Policy"
 msgstr "Cookie Policy"
 
@@ -407,7 +407,7 @@ msgstr "Does your startup tackle the climate crisis?"
 msgid "Download holding confirmations with a single click"
 msgstr "Download holding confirmations with a single click"
 
-#: src/layouts/index.jsx:196
+#: src/layouts/index.jsx:194
 msgid "Due Diligence"
 msgstr "Due Diligence"
 
@@ -443,7 +443,7 @@ msgstr "Electronic signatures<0/>"
 msgid "Email notification about upcoming vesting event"
 msgstr "Email notification about upcoming vesting event"
 
-#: src/layouts/index.jsx:193
+#: src/layouts/index.jsx:191
 msgid "Employee Incentives"
 msgstr "Employee Incentives"
 
@@ -508,12 +508,12 @@ msgstr "Every company has KPIs, and investors love seeing them in real-time"
 msgid "Exit modeling"
 msgstr "Exit modeling"
 
-#: src/layouts/index.jsx:144
+#: src/layouts/index.jsx:142
 msgid "FAQ"
 msgstr "FAQ"
 
 #: src/layouts/index.jsx:59
-#: src/layouts/index.jsx:184
+#: src/layouts/index.jsx:182
 #: src/pages/features/captable.jsx:21
 #: src/pages/features/collaboration.jsx:21
 #: src/pages/features/esop.jsx:16
@@ -553,7 +553,7 @@ msgstr "For even better protection of accounts. And our implementation is <0>ope
 msgid "Founder of Meisser Economics, Bitcoin Association Switzerland, and Wuala"
 msgstr "Founder of Meisser Economics, Bitcoin Association Switzerland, and Wuala"
 
-#: src/layouts/index.jsx:224
+#: src/layouts/index.jsx:222
 msgid "GDPR"
 msgstr "GDPR"
 
@@ -591,15 +591,15 @@ msgstr "Get the calculations right"
 msgid "Get your cap table and employee participation plans right, from the beginning. Make your financing rounds a success and engage your investors and employees. Know your data is safe and compliant."
 msgstr "Get your cap table and employee participation plans right, from the beginning. Make your financing rounds a success and engage your investors and employees. Know your data is safe and compliant."
 
-#: src/layouts/index.jsx:384
+#: src/layouts/index.jsx:382
 msgid "Get your cap table and employee participation plans right, from the beginning. Make your financing rounds a success and engage your investors and employees. Know your data is safe and compliant. Try now for free!"
 msgstr "Get your cap table and employee participation plans right, from the beginning. Make your financing rounds a success and engage your investors and employees. Know your data is safe and compliant. Try now for free!"
 
-#: src/layouts/index.jsx:141
+#: src/layouts/index.jsx:139
 msgid "Getting Started"
 msgstr "Getting Started"
 
-#: src/pages/subscribed.jsx:47
+#: src/pages/subscribed.jsx:43
 msgid "Go to Ledgy app"
 msgstr "Go to Ledgy app"
 
@@ -624,7 +624,7 @@ msgstr "HTTP headers prevent cross-site scripting and code injection (<0>A+ rati
 msgid "Healthcare & technology venture capital since 2001"
 msgstr "Healthcare & technology venture capital since 2001"
 
-#: src/layouts/index.jsx:136
+#: src/layouts/index.jsx:134
 msgid "Help"
 msgstr "Help"
 
@@ -697,7 +697,7 @@ msgstr "Investor Relations & Portfolio"
 msgid "Investor portfolio"
 msgstr "Investor portfolio"
 
-#: src/layouts/index.jsx:199
+#: src/layouts/index.jsx:197
 msgid "Investors"
 msgstr "Investors"
 
@@ -745,7 +745,7 @@ msgstr "Key performance indicators"
 msgid "Kpi chart"
 msgstr "Kpi chart"
 
-#: src/layouts/index.jsx:256
+#: src/layouts/index.jsx:254
 msgid "Language"
 msgstr "Language"
 
@@ -773,7 +773,7 @@ msgstr "Ledgy makes it easy to simulate an investment with a pro-rata distributi
 msgid "Ledgy scales with your needs. Free for startups, powerful for grown-ups."
 msgstr "Ledgy scales with your needs. Free for startups, powerful for grown-ups."
 
-#: src/layouts/index.jsx:210
+#: src/layouts/index.jsx:208
 msgid "Legal"
 msgstr "Legal"
 
@@ -817,7 +817,7 @@ msgstr "Marius has a background in computer science, graduated from Milan Univer
 msgid "Meet the team behind Ledgy that went out to help startups thrive. Learn more about the people who trust in us."
 msgstr "Meet the team behind Ledgy that went out to help startups thrive. Learn more about the people who trust in us."
 
-#: src/layouts/index.jsx:190
+#: src/layouts/index.jsx:188
 msgid "Modeling"
 msgstr "Modeling"
 
@@ -902,7 +902,7 @@ msgid "Premium"
 msgstr "Premium"
 
 #: src/layouts/index.jsx:62
-#: src/layouts/index.jsx:202
+#: src/layouts/index.jsx:200
 #: src/pages/pricing.jsx:15
 #: src/pages/pricing.jsx:24
 msgid "Pricing"
@@ -912,13 +912,13 @@ msgstr "Pricing"
 msgid "Priority support"
 msgstr "Priority support"
 
-#: src/layouts/index.jsx:122
+#: src/layouts/index.jsx:120
 #: src/pages/privacy.jsx:21
 #: src/pages/privacy.jsx:29
 msgid "Privacy"
 msgstr "Privacy"
 
-#: src/layouts/index.jsx:218
+#: src/layouts/index.jsx:216
 msgid "Privacy Policy"
 msgstr "Privacy Policy"
 
@@ -935,7 +935,7 @@ msgstr "Privacy made in Europe. Because your equity data is not for everyone."
 msgid "Pro-rata distribution"
 msgstr "Pro-rata distribution"
 
-#: src/layouts/index.jsx:179
+#: src/layouts/index.jsx:177
 msgid "Product"
 msgstr "Product"
 
@@ -1038,7 +1038,7 @@ msgstr "Secure data room"
 msgid "Secure data room, audit trail and read-only access for investors; save costly due diligence tools."
 msgstr "Secure data room, audit trail and read-only access for investors; save costly due diligence tools."
 
-#: src/layouts/index.jsx:119
+#: src/layouts/index.jsx:117
 #: src/pages/privacy.jsx:109
 #: src/pages/security.jsx:25
 #: src/pages/security.jsx:33
@@ -1085,6 +1085,10 @@ msgstr "Share your scenarios as pdf, including valuations, investments, converti
 msgid "Show cap table fully diluted"
 msgstr "Show cap table fully diluted"
 
+#: src/layouts/index.jsx:77
+msgid "Sign up"
+msgstr "Sign up"
+
 #: src/pages/features/modeling.jsx:120
 msgid "Simulation settings"
 msgstr "Simulation settings"
@@ -1129,13 +1133,12 @@ msgid "Style your reports to your needs with the rich-text editor"
 msgstr "Style your reports to your needs with the rich-text editor"
 
 #: src/components/SignupForm.jsx:52
-#: src/layouts/index.jsx:78
 msgid "Subscribe"
 msgstr "Subscribe"
 
-#: src/layouts/index.jsx:92
-msgid "Subscribe to our newsletter"
-msgstr "Subscribe to our newsletter"
+#: src/layouts/index.jsx:90
+msgid "Subscribe to the newsletter"
+msgstr "Subscribe to the newsletter"
 
 #: src/pages/subscribed.jsx:15
 msgid "Subscription confirmed"
@@ -1178,7 +1181,7 @@ msgstr "Team"
 msgid "Technical data"
 msgstr "Technical data"
 
-#: src/layouts/index.jsx:215
+#: src/layouts/index.jsx:213
 msgid "Terms of Service"
 msgstr "Terms of Service"
 
@@ -1186,7 +1189,7 @@ msgstr "Terms of Service"
 msgid "The Ledgy Blog"
 msgstr "The Ledgy Blog"
 
-#: src/layouts/index.jsx:383
+#: src/layouts/index.jsx:381
 #: src/pages/index.jsx:19
 msgid "The New Standard in Equity Management"
 msgstr "The New Standard in Equity Management"
@@ -1421,15 +1424,11 @@ msgstr "and edit log simplify due diligence"
 msgid "and numbered shares are natively supported"
 msgstr "and numbered shares are natively supported"
 
-#: src/layouts/index.jsx:96
-msgid "and stay up-to-date with everything your start-up needs"
-msgstr "and stay up-to-date with everything your start-up needs"
-
 #: src/pages/features/modeling.jsx:60
 msgid "by liquidation preferences"
 msgstr "by liquidation preferences"
 
-#: src/layouts/index.jsx:392
+#: src/layouts/index.jsx:390
 msgid "cap table, stock ledger, share register, startup, modeling, financing round, equity, esop, phantom, option plan, virtual, portfolio, reporting, investors"
 msgstr "cap table, stock ledger, share register, startup, modeling, financing round, equity, esop, phantom, option plan, virtual, portfolio, reporting, investors"
 

--- a/src/locale/en/messages.po
+++ b/src/locale/en/messages.po
@@ -30,10 +30,6 @@ msgstr "30 days trial"
 msgid "4 admins, view-only access"
 msgstr "4 admins, view-only access"
 
-#: src/components/SignupForm.jsx:18
-msgid "<0/> Signing up…"
-msgstr "<0/> Signing up…"
-
 #: src/pages/features/collaboration.jsx:79
 msgid "<0>Admin</0> Full control over the company for your co-founders"
 msgstr "<0>Admin</0> Full control over the company for your co-founders"
@@ -54,7 +50,7 @@ msgstr "A certificate of each document is automatically stored on the bitcoin bl
 msgid "A stakeholder is any holder of shares, (phantom) options, warrants, or convertibles.<0/>It does not include the company treasury or incentive pools."
 msgstr "A stakeholder is any holder of shares, (phantom) options, warrants, or convertibles.<0/>It does not include the company treasury or incentive pools."
 
-#: src/layouts/index.jsx:110
+#: src/layouts/index.jsx:113
 #: src/pages/about-us.jsx:17
 #: src/pages/about-us.jsx:25
 msgid "About us"
@@ -206,9 +202,9 @@ msgstr "Blockchain certification"
 msgid "Blockchain notary"
 msgstr "Blockchain notary"
 
-#: src/layouts/index.jsx:64
-#: src/layouts/index.jsx:113
-#: src/layouts/index.jsx:153
+#: src/layouts/index.jsx:65
+#: src/layouts/index.jsx:116
+#: src/layouts/index.jsx:156
 #: src/pages/blog.jsx:61
 msgid "Blog"
 msgstr "Blog"
@@ -241,7 +237,7 @@ msgstr "Bulk entry options"
 msgid "Calculates waterfall analysis of liquidation preferences across all rounds"
 msgstr "Calculates waterfall analysis of liquidation preferences across all rounds"
 
-#: src/layouts/index.jsx:184
+#: src/layouts/index.jsx:187
 msgid "Cap Table"
 msgstr "Cap Table"
 
@@ -258,7 +254,7 @@ msgstr "Cap table during round modeling"
 msgid "Cap table management"
 msgstr "Cap table management"
 
-#: src/layouts/index.jsx:122
+#: src/layouts/index.jsx:125
 msgid "Career"
 msgstr "Career"
 
@@ -276,7 +272,7 @@ msgstr "Coding since high school, Timo got an award for the best master thesis i
 msgid "Collaboration & Due Diligence"
 msgstr "Collaboration & Due Diligence"
 
-#: src/layouts/index.jsx:105
+#: src/layouts/index.jsx:108
 msgid "Company"
 msgstr "Company"
 
@@ -299,7 +295,7 @@ msgstr "Comprehensive transaction history"
 msgid "Contact"
 msgstr "Contact"
 
-#: src/layouts/index.jsx:125
+#: src/layouts/index.jsx:128
 msgid "Contact & Imprint"
 msgstr "Contact & Imprint"
 
@@ -315,6 +311,10 @@ msgstr "Contact us"
 #: src/pages/security.jsx:142
 msgid "Content-Security-Policy"
 msgstr "Content-Security-Policy"
+
+#: src/pages/subscribed.jsx:44
+msgid "Continue to site"
+msgstr "Continue to site"
 
 #: src/pages/features/modeling.jsx:168
 msgid "Convert financing round"
@@ -332,7 +332,7 @@ msgstr "Convert to transactions"
 msgid "Convertibles"
 msgstr "Convertibles"
 
-#: src/layouts/index.jsx:218
+#: src/layouts/index.jsx:221
 msgid "Cookie Policy"
 msgstr "Cookie Policy"
 
@@ -407,7 +407,7 @@ msgstr "Does your startup tackle the climate crisis?"
 msgid "Download holding confirmations with a single click"
 msgstr "Download holding confirmations with a single click"
 
-#: src/layouts/index.jsx:193
+#: src/layouts/index.jsx:196
 msgid "Due Diligence"
 msgstr "Due Diligence"
 
@@ -443,7 +443,7 @@ msgstr "Electronic signatures<0/>"
 msgid "Email notification about upcoming vesting event"
 msgstr "Email notification about upcoming vesting event"
 
-#: src/layouts/index.jsx:190
+#: src/layouts/index.jsx:193
 msgid "Employee Incentives"
 msgstr "Employee Incentives"
 
@@ -466,7 +466,7 @@ msgstr "Engage your employees"
 msgid "Enjoy the highest security standards"
 msgstr "Enjoy the highest security standards"
 
-#: src/components/SignupForm.jsx:82
+#: src/components/SignupForm.jsx:43
 msgid "Enter your email…"
 msgstr "Enter your email…"
 
@@ -508,12 +508,12 @@ msgstr "Every company has KPIs, and investors love seeing them in real-time"
 msgid "Exit modeling"
 msgstr "Exit modeling"
 
-#: src/layouts/index.jsx:141
+#: src/layouts/index.jsx:144
 msgid "FAQ"
 msgstr "FAQ"
 
-#: src/layouts/index.jsx:58
-#: src/layouts/index.jsx:181
+#: src/layouts/index.jsx:59
+#: src/layouts/index.jsx:184
 #: src/pages/features/captable.jsx:21
 #: src/pages/features/collaboration.jsx:21
 #: src/pages/features/esop.jsx:16
@@ -553,13 +553,9 @@ msgstr "For even better protection of accounts. And our implementation is <0>ope
 msgid "Founder of Meisser Economics, Bitcoin Association Switzerland, and Wuala"
 msgstr "Founder of Meisser Economics, Bitcoin Association Switzerland, and Wuala"
 
-#: src/layouts/index.jsx:221
+#: src/layouts/index.jsx:224
 msgid "GDPR"
 msgstr "GDPR"
-
-#: src/components/SignupForm.jsx:22
-msgid "Get Started"
-msgstr "Get Started"
 
 #: src/pages/index.jsx:40
 msgid "Get Started Free"
@@ -595,13 +591,17 @@ msgstr "Get the calculations right"
 msgid "Get your cap table and employee participation plans right, from the beginning. Make your financing rounds a success and engage your investors and employees. Know your data is safe and compliant."
 msgstr "Get your cap table and employee participation plans right, from the beginning. Make your financing rounds a success and engage your investors and employees. Know your data is safe and compliant."
 
-#: src/layouts/index.jsx:381
+#: src/layouts/index.jsx:384
 msgid "Get your cap table and employee participation plans right, from the beginning. Make your financing rounds a success and engage your investors and employees. Know your data is safe and compliant. Try now for free!"
 msgstr "Get your cap table and employee participation plans right, from the beginning. Make your financing rounds a success and engage your investors and employees. Know your data is safe and compliant. Try now for free!"
 
-#: src/layouts/index.jsx:138
+#: src/layouts/index.jsx:141
 msgid "Getting Started"
 msgstr "Getting Started"
+
+#: src/pages/subscribed.jsx:47
+msgid "Go to Ledgy app"
+msgstr "Go to Ledgy app"
 
 #: src/pages/features/esop.jsx:80
 msgid "Grant options, phantom options, warrants or add inverse vesting to stock transactions"
@@ -624,7 +624,7 @@ msgstr "HTTP headers prevent cross-site scripting and code injection (<0>A+ rati
 msgid "Healthcare & technology venture capital since 2001"
 msgstr "Healthcare & technology venture capital since 2001"
 
-#: src/layouts/index.jsx:133
+#: src/layouts/index.jsx:136
 msgid "Help"
 msgstr "Help"
 
@@ -697,7 +697,7 @@ msgstr "Investor Relations & Portfolio"
 msgid "Investor portfolio"
 msgstr "Investor portfolio"
 
-#: src/layouts/index.jsx:196
+#: src/layouts/index.jsx:199
 msgid "Investors"
 msgstr "Investors"
 
@@ -745,7 +745,7 @@ msgstr "Key performance indicators"
 msgid "Kpi chart"
 msgstr "Kpi chart"
 
-#: src/layouts/index.jsx:253
+#: src/layouts/index.jsx:256
 msgid "Language"
 msgstr "Language"
 
@@ -773,7 +773,7 @@ msgstr "Ledgy makes it easy to simulate an investment with a pro-rata distributi
 msgid "Ledgy scales with your needs. Free for startups, powerful for grown-ups."
 msgstr "Ledgy scales with your needs. Free for startups, powerful for grown-ups."
 
-#: src/layouts/index.jsx:207
+#: src/layouts/index.jsx:210
 msgid "Legal"
 msgstr "Legal"
 
@@ -789,7 +789,7 @@ msgstr "Let’s Get In Touch"
 msgid "Liquidation preferences"
 msgstr "Liquidation preferences"
 
-#: src/layouts/index.jsx:73
+#: src/layouts/index.jsx:74
 msgid "Log In"
 msgstr "Log In"
 
@@ -817,7 +817,7 @@ msgstr "Marius has a background in computer science, graduated from Milan Univer
 msgid "Meet the team behind Ledgy that went out to help startups thrive. Learn more about the people who trust in us."
 msgstr "Meet the team behind Ledgy that went out to help startups thrive. Learn more about the people who trust in us."
 
-#: src/layouts/index.jsx:187
+#: src/layouts/index.jsx:190
 msgid "Modeling"
 msgstr "Modeling"
 
@@ -828,10 +828,6 @@ msgstr "Multiple rounds, 3 scenarios"
 #: src/pages/privacy.jsx:84
 msgid "Name, email, address and any other details you provide. Provision of our services and management of your subscription. Providing you with updates about our services"
 msgstr "Name, email, address and any other details you provide. Provision of our services and management of your subscription. Providing you with updates about our services"
-
-#: src/layouts/index.jsx:93
-msgid "No credit card required"
-msgstr "No credit card required"
 
 #: src/pages/privacy.jsx:130
 msgid "Nobody has any access to the equity data you provide. They are safely stored at a secure data center in France. Your stakeholders have no access and don’t get emails before you explicitly invite them"
@@ -853,7 +849,7 @@ msgstr "Numbers are checked for consistency, giving you the peace of mind that n
 msgid "One of the most active Swiss early-stage angel investors"
 msgstr "One of the most active Swiss early-stage angel investors"
 
-#: src/components/SignupForm.jsx:98
+#: src/components/SignupForm.jsx:56
 msgid "Oops. This email address is invalid."
 msgstr "Oops. This email address is invalid."
 
@@ -905,8 +901,8 @@ msgstr "Portfolio history"
 msgid "Premium"
 msgstr "Premium"
 
-#: src/layouts/index.jsx:61
-#: src/layouts/index.jsx:199
+#: src/layouts/index.jsx:62
+#: src/layouts/index.jsx:202
 #: src/pages/pricing.jsx:15
 #: src/pages/pricing.jsx:24
 msgid "Pricing"
@@ -916,13 +912,13 @@ msgstr "Pricing"
 msgid "Priority support"
 msgstr "Priority support"
 
-#: src/layouts/index.jsx:119
+#: src/layouts/index.jsx:122
 #: src/pages/privacy.jsx:21
 #: src/pages/privacy.jsx:29
 msgid "Privacy"
 msgstr "Privacy"
 
-#: src/layouts/index.jsx:215
+#: src/layouts/index.jsx:218
 msgid "Privacy Policy"
 msgstr "Privacy Policy"
 
@@ -939,7 +935,7 @@ msgstr "Privacy made in Europe. Because your equity data is not for everyone."
 msgid "Pro-rata distribution"
 msgstr "Pro-rata distribution"
 
-#: src/layouts/index.jsx:176
+#: src/layouts/index.jsx:179
 msgid "Product"
 msgstr "Product"
 
@@ -1042,7 +1038,7 @@ msgstr "Secure data room"
 msgid "Secure data room, audit trail and read-only access for investors; save costly due diligence tools."
 msgstr "Secure data room, audit trail and read-only access for investors; save costly due diligence tools."
 
-#: src/layouts/index.jsx:116
+#: src/layouts/index.jsx:119
 #: src/pages/privacy.jsx:109
 #: src/pages/security.jsx:25
 #: src/pages/security.jsx:33
@@ -1089,10 +1085,6 @@ msgstr "Share your scenarios as pdf, including valuations, investments, converti
 msgid "Show cap table fully diluted"
 msgstr "Show cap table fully diluted"
 
-#: src/layouts/index.jsx:76
-msgid "Sign Up"
-msgstr "Sign Up"
-
 #: src/pages/features/modeling.jsx:120
 msgid "Simulation settings"
 msgstr "Simulation settings"
@@ -1136,6 +1128,19 @@ msgstr "Strong passwords"
 msgid "Style your reports to your needs with the rich-text editor"
 msgstr "Style your reports to your needs with the rich-text editor"
 
+#: src/components/SignupForm.jsx:52
+#: src/layouts/index.jsx:78
+msgid "Subscribe"
+msgstr "Subscribe"
+
+#: src/layouts/index.jsx:92
+msgid "Subscribe to our newsletter"
+msgstr "Subscribe to our newsletter"
+
+#: src/pages/subscribed.jsx:15
+msgid "Subscription confirmed"
+msgstr "Subscription confirmed"
+
 #: src/pages/features/investors.jsx:78
 msgid "Successful companies share regular updates with their stakeholders, holding themselves accountable"
 msgstr "Successful companies share regular updates with their stakeholders, holding themselves accountable"
@@ -1173,7 +1178,7 @@ msgstr "Team"
 msgid "Technical data"
 msgstr "Technical data"
 
-#: src/layouts/index.jsx:212
+#: src/layouts/index.jsx:215
 msgid "Terms of Service"
 msgstr "Terms of Service"
 
@@ -1181,7 +1186,7 @@ msgstr "Terms of Service"
 msgid "The Ledgy Blog"
 msgstr "The Ledgy Blog"
 
-#: src/layouts/index.jsx:380
+#: src/layouts/index.jsx:383
 #: src/pages/index.jsx:19
 msgid "The New Standard in Equity Management"
 msgstr "The New Standard in Equity Management"
@@ -1266,10 +1271,6 @@ msgstr "Trust your Cap Table"
 #: src/pages/pricing.jsx:152
 msgid "Try 30 days free"
 msgstr "Try 30 days free"
-
-#: src/layouts/index.jsx:89
-msgid "Try Ledgy now for free"
-msgstr "Try Ledgy now for free"
 
 #: src/pages/pricing.jsx:81
 #: src/pages/security.jsx:92
@@ -1420,11 +1421,15 @@ msgstr "and edit log simplify due diligence"
 msgid "and numbered shares are natively supported"
 msgstr "and numbered shares are natively supported"
 
+#: src/layouts/index.jsx:96
+msgid "and stay up-to-date with everything your start-up needs"
+msgstr "and stay up-to-date with everything your start-up needs"
+
 #: src/pages/features/modeling.jsx:60
 msgid "by liquidation preferences"
 msgstr "by liquidation preferences"
 
-#: src/layouts/index.jsx:389
+#: src/layouts/index.jsx:392
 msgid "cap table, stock ledger, share register, startup, modeling, financing round, equity, esop, phantom, option plan, virtual, portfolio, reporting, investors"
 msgstr "cap table, stock ledger, share register, startup, modeling, financing round, equity, esop, phantom, option plan, virtual, portfolio, reporting, investors"
 

--- a/src/locale/en/messages.po
+++ b/src/locale/en/messages.po
@@ -1432,6 +1432,10 @@ msgstr "by liquidation preferences"
 msgid "cap table, stock ledger, share register, startup, modeling, financing round, equity, esop, phantom, option plan, virtual, portfolio, reporting, investors"
 msgstr "cap table, stock ledger, share register, startup, modeling, financing round, equity, esop, phantom, option plan, virtual, portfolio, reporting, investors"
 
+#: src/layouts/index.jsx:94
+msgid "for monthly updates on new features and start-up resources"
+msgstr "for monthly updates on new features and start-up resources"
+
 #: src/pages/pricing.jsx:38
 msgid "free"
 msgstr "free"

--- a/src/locale/fr/messages.po
+++ b/src/locale/fr/messages.po
@@ -30,10 +30,6 @@ msgstr "30 jours d’essai"
 msgid "4 admins, view-only access"
 msgstr "4 admins, accès en vue seule"
 
-#: src/components/SignupForm.jsx:18
-msgid "<0/> Signing up…"
-msgstr "<0/> S’inscrire…"
-
 #: src/pages/features/collaboration.jsx:79
 msgid "<0>Admin</0> Full control over the company for your co-founders"
 msgstr "<0>Admin</0> Contrôle total de l’entreprise pour tes cofondateurs"
@@ -54,12 +50,15 @@ msgstr "Un certificat de chaque document est automatiquement stocké sur la bitc
 msgid "A stakeholder is any holder of shares, (phantom) options, warrants, or convertibles.<0/>It does not include the company treasury or incentive pools."
 msgstr "Un stakeholder est tout détenteur d’actions, d’options (virtuelles), warrants ou de billets convertibles.<0/>Il n’inclut pas la société elle-même ni les pools d’options."
 
-#: src/layouts/index.jsx:110 src/pages/about-us.jsx:17
+#: src/layouts/index.jsx:113
+#: src/pages/about-us.jsx:17
 #: src/pages/about-us.jsx:25
 msgid "About us"
 msgstr "À propos de nous"
 
-#: src/pages/pricing.jsx:60 src/pages/pricing.jsx:125 src/pages/pricing.jsx:188
+#: src/pages/pricing.jsx:60
+#: src/pages/pricing.jsx:125
+#: src/pages/pricing.jsx:188
 msgid "Access rights"
 msgstr "Droits d’accès"
 
@@ -91,7 +90,8 @@ msgstr "Ajouter un vesting"
 msgid "Add vesting or inverse vesting to any transaction"
 msgstr "Ajouter un vesting à toute transaction"
 
-#: src/pages/features/modeling.jsx:53 src/pages/features/modeling.jsx:111
+#: src/pages/features/modeling.jsx:53
+#: src/pages/features/modeling.jsx:111
 msgid "Adjust your simulations"
 msgstr "Ajuste tes simulations"
 
@@ -107,7 +107,8 @@ msgstr "Les fonctions Standard"
 msgid "All data is stored at an <0>independent provider</0> in France"
 msgstr "Toutes les données sont stockées chez un prestataire <0>indépendant </0> en France"
 
-#: src/components/Feature.jsx:89 src/pages/features.jsx:23
+#: src/components/Feature.jsx:89
+#: src/pages/features.jsx:23
 msgid "All you need in one place"
 msgstr "Tout ce dont tu as besoin au même endroit"
 
@@ -123,7 +124,8 @@ msgstr "Portefeuille toujours à jour, géré par tes startups"
 msgid "Analyze it by stakeholder, share class, stakeholder group and view it with all, outstanding or diluted shares"
 msgstr "Analyse-le par actionnaire, catégorie d’actions, groupe d’actionnaires et visualise-le avec toutes les actions en circulation ou diluées"
 
-#: src/pages/features/esop.jsx:92 src/pages/pricing.jsx:115
+#: src/pages/features/esop.jsx:92
+#: src/pages/pricing.jsx:115
 msgid "Any vesting schedule"
 msgstr "Tout calendrier de vesting"
 
@@ -147,7 +149,8 @@ msgstr "Chez Ledgy, nous prenons ta sécurité au sérieux. Des mots de passe s�
 msgid "Attach doc to transaction"
 msgstr "Joindre le document à la transaction"
 
-#: src/pages/features/captable.jsx:53 src/pages/features/captable.jsx:136
+#: src/pages/features/captable.jsx:53
+#: src/pages/features/captable.jsx:136
 msgid "Attach documents"
 msgstr "Joins des documents"
 
@@ -199,7 +202,9 @@ msgstr "Certification Blockchain"
 msgid "Blockchain notary"
 msgstr "Notaire Blockchain"
 
-#: src/layouts/index.jsx:64 src/layouts/index.jsx:113 src/layouts/index.jsx:153
+#: src/layouts/index.jsx:65
+#: src/layouts/index.jsx:116
+#: src/layouts/index.jsx:156
 #: src/pages/blog.jsx:61
 msgid "Blog"
 msgstr "Blog"
@@ -232,11 +237,12 @@ msgstr "Options d’entrée en bloc"
 msgid "Calculates waterfall analysis of liquidation preferences across all rounds"
 msgstr "Calcule l’analyse en cascade des préférences de liquidation à travers toutes les levées de fonds"
 
-#: src/layouts/index.jsx:184
+#: src/layouts/index.jsx:187
 msgid "Cap Table"
 msgstr "Cap Table"
 
-#: src/components/Feature.jsx:99 src/pages/features.jsx:58
+#: src/components/Feature.jsx:99
+#: src/pages/features.jsx:58
 msgid "Cap Table Management"
 msgstr "Gestion du cap table"
 
@@ -248,7 +254,7 @@ msgstr "Cap table pendant la levée de fonds"
 msgid "Cap table management"
 msgstr "Gestion du cap table"
 
-#: src/layouts/index.jsx:122
+#: src/layouts/index.jsx:125
 msgid "Career"
 msgstr "Carrière"
 
@@ -260,16 +266,18 @@ msgstr "Choisis de n’afficher que les pools ou la vue détaillée avec les par
 msgid "Coding since high school, Timo got an award for the best master thesis in computer science and worked one year as a computer engineer in robotics"
 msgstr "Codant depuis le lycée, Timo a obtenu un prix pour le meilleur mémoire de maîtrise en informatique et a travaillé un an comme ingénieur en robotique"
 
-#: src/components/Feature.jsx:101 src/pages/features/collaboration.jsx:20
+#: src/components/Feature.jsx:101
+#: src/pages/features/collaboration.jsx:20
 #: src/pages/features.jsx:104
 msgid "Collaboration & Due Diligence"
 msgstr "Collaboration et diligence raisonnable"
 
-#: src/layouts/index.jsx:105
+#: src/layouts/index.jsx:108
 msgid "Company"
 msgstr "Société"
 
-#: src/pages/features/modeling.jsx:47 src/pages/features/modeling.jsx:95
+#: src/pages/features/modeling.jsx:47
+#: src/pages/features/modeling.jsx:95
 #: src/pages/features/modeling.jsx:105
 msgid "Compare and share scenarios"
 msgstr "Compare et partage des scénarios"
@@ -282,11 +290,12 @@ msgstr "Complète ton portefeuille"
 msgid "Comprehensive transaction history"
 msgstr "Historique complet des transactions"
 
-#: src/pages/contact.jsx:10 src/pages/contact.jsx:74
+#: src/pages/contact.jsx:10
+#: src/pages/contact.jsx:74
 msgid "Contact"
 msgstr "Contact"
 
-#: src/layouts/index.jsx:125
+#: src/layouts/index.jsx:128
 msgid "Contact & Imprint"
 msgstr "Contact & Mentions légales"
 
@@ -294,13 +303,18 @@ msgstr "Contact & Mentions légales"
 msgid "Contact data, usage statistics, and technical data"
 msgstr "Données de contact, statistiques d’utilisation et données techniques"
 
-#: src/pages/pricing.jsx:165 src/pages/pricing.jsx:219
+#: src/pages/pricing.jsx:165
+#: src/pages/pricing.jsx:219
 msgid "Contact us"
 msgstr "Contactez-nous"
 
 #: src/pages/security.jsx:142
 msgid "Content-Security-Policy"
 msgstr "Politique de sécurité du contenu"
+
+#: src/pages/subscribed.jsx:44
+msgid "Continue to site"
+msgstr ""
 
 #: src/pages/features/modeling.jsx:168
 msgid "Convert financing round"
@@ -318,7 +332,7 @@ msgstr "Convertir en transactions"
 msgid "Convertibles"
 msgstr "Décapotables"
 
-#: src/layouts/index.jsx:218
+#: src/layouts/index.jsx:221
 msgid "Cookie Policy"
 msgstr "Politique de Cookies"
 
@@ -350,7 +364,8 @@ msgstr "Data room, piste d’audits et accès en lecture seule pour les investis
 msgid "Digital entrepreneur and investor. Security, crypto & privacy expert"
 msgstr "Entrepreneur et investisseur en technologies digitales. Expert en sécurité et cryptographie"
 
-#: src/pages/features/esop.jsx:137 src/pages/features/modeling.jsx:140
+#: src/pages/features/esop.jsx:137
+#: src/pages/features/modeling.jsx:140
 msgid "Diluted cap table"
 msgstr "Cap table dilué"
 
@@ -374,7 +389,9 @@ msgstr "Liens aux documents"
 msgid "Document management"
 msgstr "Gestion des documents"
 
-#: src/pages/pricing.jsx:66 src/pages/pricing.jsx:131 src/pages/pricing.jsx:194
+#: src/pages/pricing.jsx:66
+#: src/pages/pricing.jsx:131
+#: src/pages/pricing.jsx:194
 msgid "Document storage"
 msgstr "Stockage des documents"
 
@@ -390,7 +407,7 @@ msgstr "Ta startup contribue-t-elle à la lutte contre le changement climatique?
 msgid "Download holding confirmations with a single click"
 msgstr "Télécharge les confirmations de possession d’un simple clic"
 
-#: src/layouts/index.jsx:193
+#: src/layouts/index.jsx:196
 msgid "Due Diligence"
 msgstr "Diligence raisonnable"
 
@@ -426,11 +443,12 @@ msgstr "Signatures électroniques<0/>"
 msgid "Email notification about upcoming vesting event"
 msgstr "Notification par e-mail d’évènement de complétion de vesting imminent"
 
-#: src/layouts/index.jsx:190
+#: src/layouts/index.jsx:193
 msgid "Employee Incentives"
 msgstr "Participation des employés"
 
-#: src/components/Feature.jsx:98 src/pages/features/esop.jsx:25
+#: src/components/Feature.jsx:98
+#: src/pages/features/esop.jsx:25
 #: src/pages/features.jsx:33
 msgid "Employee Participation Plans"
 msgstr "Plans de participation des employés"
@@ -439,7 +457,8 @@ msgstr "Plans de participation des employés"
 msgid "Encrypted connection"
 msgstr "Connexion cryptée"
 
-#: src/pages/features/esop.jsx:48 src/pages/features/esop.jsx:109
+#: src/pages/features/esop.jsx:48
+#: src/pages/features/esop.jsx:109
 msgid "Engage your employees"
 msgstr "Mobilise tes employés"
 
@@ -447,7 +466,7 @@ msgstr "Mobilise tes employés"
 msgid "Enjoy the highest security standards"
 msgstr "Bénéficie des plus hauts standards de sécurité"
 
-#: src/components/SignupForm.jsx:82
+#: src/components/SignupForm.jsx:43
 msgid "Enter your email…"
 msgstr "Entre ton adresse email…"
 
@@ -463,7 +482,8 @@ msgstr "Entrepreneur, business angel, fondateur de Doodle.com"
 msgid "Entrepreneur, technologist, founder of Doodle.com"
 msgstr "Entrepreneur, technologist, fondateur de Doodle.com"
 
-#: src/pages/privacy.jsx:77 src/pages/privacy.jsx:129
+#: src/pages/privacy.jsx:77
+#: src/pages/privacy.jsx:129
 msgid "Equity data"
 msgstr "Données sur les capitaux propres"
 
@@ -483,18 +503,23 @@ msgstr "La symbiose européenne entre les fonds de capital-risque et le réseau 
 msgid "Every company has KPIs, and investors love seeing them in real-time"
 msgstr "Chaque entreprise a des indicateurs de performance clés, et les investisseurs adorent les voir en temps réel"
 
-#: src/pages/features/modeling.jsx:173 src/pages/features/modeling.jsx:186
+#: src/pages/features/modeling.jsx:173
+#: src/pages/features/modeling.jsx:186
 msgid "Exit modeling"
 msgstr "Modélisation de stratégie de sortie"
 
-#: src/layouts/index.jsx:141
+#: src/layouts/index.jsx:144
 msgid "FAQ"
 msgstr "FAQ"
 
-#: src/layouts/index.jsx:58 src/layouts/index.jsx:181
-#: src/pages/features/captable.jsx:21 src/pages/features/collaboration.jsx:21
-#: src/pages/features/esop.jsx:16 src/pages/features/investors.jsx:21
-#: src/pages/features/modeling.jsx:21 src/pages/features.jsx:14
+#: src/layouts/index.jsx:59
+#: src/layouts/index.jsx:184
+#: src/pages/features/captable.jsx:21
+#: src/pages/features/collaboration.jsx:21
+#: src/pages/features/esop.jsx:16
+#: src/pages/features/investors.jsx:21
+#: src/pages/features/modeling.jsx:21
+#: src/pages/features.jsx:14
 msgid "Features"
 msgstr "Fonctionalités"
 
@@ -526,13 +551,9 @@ msgstr "Pour une meilleure protection des comptes. Et notre implémentation est 
 msgid "Founder of Meisser Economics, Bitcoin Association Switzerland, and Wuala"
 msgstr "Fondateur de Meisser Economics, Bitcoin Association Switzerland, et Wuala"
 
-#: src/layouts/index.jsx:221
+#: src/layouts/index.jsx:224
 msgid "GDPR"
 msgstr "RGPD"
-
-#: src/components/SignupForm.jsx:22
-msgid "Get Started"
-msgstr "Commencer"
 
 #: src/pages/index.jsx:40
 msgid "Get Started Free"
@@ -558,7 +579,8 @@ msgstr "Commencer"
 msgid "Get started in minutes with the copy-paste spreadsheet importer"
 msgstr "Démarre en quelques minutes avec un simple copier-coller dans l’importateur de fichiers excel"
 
-#: src/pages/features/modeling.jsx:41 src/pages/features/modeling.jsx:76
+#: src/pages/features/modeling.jsx:41
+#: src/pages/features/modeling.jsx:76
 #: src/pages/features/modeling.jsx:88
 msgid "Get the calculations right"
 msgstr "Effectue les bons calculs"
@@ -567,13 +589,17 @@ msgstr "Effectue les bons calculs"
 msgid "Get your cap table and employee participation plans right, from the beginning. Make your financing rounds a success and engage your investors and employees. Know your data is safe and compliant."
 msgstr "Bien comprendre ton cap table et tes plans d’actionnariat, dès le début. Fais de tes levées de fond un succès et mobilise tes investisseurs et tes employés. Sois sûr que tes données soient en sécurité."
 
-#: src/layouts/index.jsx:381
+#: src/layouts/index.jsx:384
 msgid "Get your cap table and employee participation plans right, from the beginning. Make your financing rounds a success and engage your investors and employees. Know your data is safe and compliant. Try now for free!"
 msgstr "Configure ton cap table et tes plans d’actionnariat des employés correctement, dès le début. Fais de tes levées de fonds un succès et mobilise tes investisseurs et tes employés. Aies la tranquillité d’esprit que tes données sont sûres et conformes. Essaye maintenant gratuitement !"
 
-#: src/layouts/index.jsx:138
+#: src/layouts/index.jsx:141
 msgid "Getting Started"
 msgstr "Commencer"
+
+#: src/pages/subscribed.jsx:47
+msgid "Go to Ledgy app"
+msgstr ""
 
 #: src/pages/features/esop.jsx:80
 msgid "Grant options, phantom options, warrants or add inverse vesting to stock transactions"
@@ -596,7 +622,7 @@ msgstr "Les en-têtes HTTP empêchent les scripts intersites et l’injection de
 msgid "Healthcare & technology venture capital since 2001"
 msgstr "Capital de risque dans le domaine de la santé et de la technologie depuis 2001"
 
-#: src/layouts/index.jsx:133
+#: src/layouts/index.jsx:136
 msgid "Help"
 msgstr "Aide"
 
@@ -609,7 +635,8 @@ msgid "Holding confirmation"
 msgstr "Confirmation de possession"
 
 #: src/pages/features/collaboration.jsx:59
-#: src/pages/features/collaboration.jsx:169 src/pages/pricing.jsx:72
+#: src/pages/features/collaboration.jsx:169
+#: src/pages/pricing.jsx:72
 msgid "Holding confirmations"
 msgstr "Confirmations de possession"
 
@@ -657,8 +684,10 @@ msgstr "Cap table intuitif, juridiquement valide et exempt d’erreurs dès le d
 msgid "Investor & consultant (Farmy.ch, Flatfox.ch), founder of Students.ch"
 msgstr "Investisseur & consultant (Farmy.ch, Flatfox.ch), fondateur de Students.ch"
 
-#: src/components/Feature.jsx:102 src/pages/features/investors.jsx:20
-#: src/pages/features/investors.jsx:30 src/pages/features.jsx:126
+#: src/components/Feature.jsx:102
+#: src/pages/features/investors.jsx:20
+#: src/pages/features/investors.jsx:30
+#: src/pages/features.jsx:126
 msgid "Investor Relations & Portfolio"
 msgstr "Relations investisseurs et portfolio"
 
@@ -666,7 +695,7 @@ msgstr "Relations investisseurs et portfolio"
 msgid "Investor portfolio"
 msgstr "Portefeuille d’investisseurs"
 
-#: src/layouts/index.jsx:196
+#: src/layouts/index.jsx:199
 msgid "Investors"
 msgstr "Investisseurs"
 
@@ -714,7 +743,7 @@ msgstr "Indicateurs clés de performance"
 msgid "Kpi chart"
 msgstr "Diagramme Kpi"
 
-#: src/layouts/index.jsx:253
+#: src/layouts/index.jsx:256
 msgid "Language"
 msgstr "Langue"
 
@@ -742,7 +771,7 @@ msgstr "Ledgy facilite la simulation d’un investissement avec une distribution
 msgid "Ledgy scales with your needs. Free for startups, powerful for grown-ups."
 msgstr "Ledgy s’adapte à tes besoins. Gratuit pour les startups, puissant pour les scale-ups."
 
-#: src/layouts/index.jsx:207
+#: src/layouts/index.jsx:210
 msgid "Legal"
 msgstr "Légal"
 
@@ -758,7 +787,7 @@ msgstr "Prenons contact"
 msgid "Liquidation preferences"
 msgstr "Préférences de liquidation"
 
-#: src/layouts/index.jsx:73
+#: src/layouts/index.jsx:74
 msgid "Log In"
 msgstr "Connexion"
 
@@ -786,7 +815,7 @@ msgstr "Marius a une formation en informatique, est diplômé de l’Université
 msgid "Meet the team behind Ledgy that went out to help startups thrive. Learn more about the people who trust in us."
 msgstr "Rencontre l’équipe derrière Ledgy qui pour mission d’aider les startups à prospérer. En savoir plus sur les personnes qui nous font confiance."
 
-#: src/layouts/index.jsx:187
+#: src/layouts/index.jsx:190
 msgid "Modeling"
 msgstr "Modélisation"
 
@@ -797,10 +826,6 @@ msgstr "3 scénarios"
 #: src/pages/privacy.jsx:84
 msgid "Name, email, address and any other details you provide. Provision of our services and management of your subscription. Providing you with updates about our services"
 msgstr "Nom, adresse email, adresse et tout autre renseignement que tu nous fournis. Prestation de nos services et gestion de ton abonnement. Te fournir des mises à jour sur nos services"
-
-#: src/layouts/index.jsx:93
-msgid "No credit card required"
-msgstr "Aucune carte de crédit requise"
 
 #: src/pages/privacy.jsx:130
 msgid "Nobody has any access to the equity data you provide. They are safely stored at a secure data center in France. Your stakeholders have no access and don’t get emails before you explicitly invite them"
@@ -822,7 +847,7 @@ msgstr "La cohérence des numéros est vérifiée, ce qui te donne la tranquilli
 msgid "One of the most active Swiss early-stage angel investors"
 msgstr "L’un des angel investors suisses les plus actifs en early-stage"
 
-#: src/components/SignupForm.jsx:98
+#: src/components/SignupForm.jsx:56
 msgid "Oops. This email address is invalid."
 msgstr "Oups. Cette adresse e-mail n’est pas valide."
 
@@ -854,7 +879,8 @@ msgstr "Joue avec les paramètres qui favorisent différents actionnaires, vois 
 msgid "Pooled investment"
 msgstr "Investissement en fond commun"
 
-#: src/pages/features/captable.jsx:47 src/pages/features/captable.jsx:117
+#: src/pages/features/captable.jsx:47
+#: src/pages/features/captable.jsx:117
 #: src/pages/pricing.jsx:75
 msgid "Pooled investments"
 msgstr "Investissement en fond commun"
@@ -863,7 +889,8 @@ msgstr "Investissement en fond commun"
 msgid "Pooled investments are common in many countries, Ledgy helps you keep them organized"
 msgstr "Les placements collectifs en pool sont courants dans de nombreux pays, Ledgy t’aide à les garder organisés"
 
-#: src/pages/features/investors.jsx:59 src/pages/features/investors.jsx:122
+#: src/pages/features/investors.jsx:59
+#: src/pages/features/investors.jsx:122
 #: src/pages/features/investors.jsx:128
 msgid "Portfolio history"
 msgstr "Historique du portefeuille"
@@ -872,7 +899,9 @@ msgstr "Historique du portefeuille"
 msgid "Premium"
 msgstr "Premium"
 
-#: src/layouts/index.jsx:61 src/layouts/index.jsx:199 src/pages/pricing.jsx:15
+#: src/layouts/index.jsx:62
+#: src/layouts/index.jsx:202
+#: src/pages/pricing.jsx:15
 #: src/pages/pricing.jsx:24
 msgid "Pricing"
 msgstr "Tarifs"
@@ -881,11 +910,13 @@ msgstr "Tarifs"
 msgid "Priority support"
 msgstr "Support prioritaire"
 
-#: src/layouts/index.jsx:119 src/pages/privacy.jsx:21 src/pages/privacy.jsx:29
+#: src/layouts/index.jsx:122
+#: src/pages/privacy.jsx:21
+#: src/pages/privacy.jsx:29
 msgid "Privacy"
 msgstr "Confidentialité"
 
-#: src/layouts/index.jsx:215
+#: src/layouts/index.jsx:218
 msgid "Privacy Policy"
 msgstr "Politique de confidentialité"
 
@@ -893,7 +924,8 @@ msgstr "Politique de confidentialité"
 msgid "Privacy made in Europe"
 msgstr "Privacy made in Europe"
 
-#: src/pages/privacy.jsx:22 src/pages/privacy.jsx:45
+#: src/pages/privacy.jsx:22
+#: src/pages/privacy.jsx:45
 msgid "Privacy made in Europe. Because your equity data is not for everyone."
 msgstr "Confidentialité made in Europe. Parce que tes données ne doivent pas être accessible à tout le monde."
 
@@ -901,11 +933,12 @@ msgstr "Confidentialité made in Europe. Parce que tes données ne doivent pas �
 msgid "Pro-rata distribution"
 msgstr "Distribution au prorata"
 
-#: src/layouts/index.jsx:176
+#: src/layouts/index.jsx:179
 msgid "Product"
 msgstr "Produit"
 
-#: src/pages/features/investors.jsx:53 src/pages/features/investors.jsx:109
+#: src/pages/features/investors.jsx:53
+#: src/pages/features/investors.jsx:109
 msgid "Professional portfolio"
 msgstr "Portefeuille professionnel"
 
@@ -929,7 +962,8 @@ msgstr "Accédez rapidement aux documents à travers les transactions qui y sont
 msgid "Quickly pull up legal documents by the information of their linked transactions"
 msgstr "Retrouve rapidement les documents juridiques par l’information de leurs transactions correspondantes"
 
-#: src/components/SecurityRow.jsx:22 src/components/SecurityRow.jsx:37
+#: src/components/SecurityRow.jsx:22
+#: src/components/SecurityRow.jsx:37
 #: src/pages/blog.jsx:49
 msgid "Read more"
 msgstr "Lire plus"
@@ -938,7 +972,8 @@ msgstr "Lire plus"
 msgid "Record of edits"
 msgstr "Registre des modifications"
 
-#: src/pages/features/investors.jsx:41 src/pages/features/investors.jsx:76
+#: src/pages/features/investors.jsx:41
+#: src/pages/features/investors.jsx:76
 msgid "Recurring reports"
 msgstr "Rapports récurrents"
 
@@ -954,7 +989,8 @@ msgstr "Rapport"
 msgid "Reporting"
 msgstr "Rapport"
 
-#: src/components/Feature.jsx:100 src/pages/features.jsx:80
+#: src/components/Feature.jsx:100
+#: src/pages/features.jsx:80
 msgid "Round & Exit Modeling"
 msgstr "Modélisation de levée de fonds et de sorties"
 
@@ -962,7 +998,8 @@ msgstr "Modélisation de levée de fonds et de sorties"
 msgid "Round Modeling"
 msgstr "Modélisation de levée de fonds"
 
-#: src/pages/features/modeling.jsx:20 src/pages/features/modeling.jsx:30
+#: src/pages/features/modeling.jsx:20
+#: src/pages/features/modeling.jsx:30
 msgid "Round and Exit Modeling"
 msgstr "Modélisation de levée de fonds et de sorties"
 
@@ -999,8 +1036,10 @@ msgstr "Data room sécurisée"
 msgid "Secure data room, audit trail and read-only access for investors; save costly due diligence tools."
 msgstr "Data room sécurisée, piste d’audits et accès en lecture seule pour les investisseurs; économise sur les outils coûteux de diligence raisonnable."
 
-#: src/layouts/index.jsx:116 src/pages/privacy.jsx:109
-#: src/pages/security.jsx:25 src/pages/security.jsx:33
+#: src/layouts/index.jsx:119
+#: src/pages/privacy.jsx:109
+#: src/pages/security.jsx:25
+#: src/pages/security.jsx:33
 msgid "Security"
 msgstr "Sécurité"
 
@@ -1044,10 +1083,6 @@ msgstr "Partage tes scénarios au format pdf, y compris les évaluations de ton 
 msgid "Show cap table fully diluted"
 msgstr "Afficher le cap table entièrement dilué"
 
-#: src/layouts/index.jsx:76
-msgid "Sign Up"
-msgstr "S’inscrire"
-
 #: src/pages/features/modeling.jsx:120
 msgid "Simulation settings"
 msgstr "Paramètres de simulation"
@@ -1060,8 +1095,10 @@ msgstr "Space elevator"
 msgid "Speed up your onboarding process with the bulk import feature"
 msgstr "Accélère l’import de tes données grâce à la fonction d’importation en masse"
 
-#: src/pages/features/captable.jsx:59 src/pages/features/captable.jsx:157
-#: src/pages/features/esop.jsx:54 src/pages/features/esop.jsx:152
+#: src/pages/features/captable.jsx:59
+#: src/pages/features/captable.jsx:157
+#: src/pages/features/esop.jsx:54
+#: src/pages/features/esop.jsx:152
 msgid "Spreadsheet importer"
 msgstr "Importateur de feuilles de calcul"
 
@@ -1089,6 +1126,19 @@ msgstr "Mots de passe forts"
 msgid "Style your reports to your needs with the rich-text editor"
 msgstr "Personnalise tes rapports selon tes besoins avec l’éditeur de texte"
 
+#: src/components/SignupForm.jsx:52
+#: src/layouts/index.jsx:78
+msgid "Subscribe"
+msgstr ""
+
+#: src/layouts/index.jsx:92
+msgid "Subscribe to our newsletter"
+msgstr ""
+
+#: src/pages/subscribed.jsx:15
+msgid "Subscription confirmed"
+msgstr ""
+
 #: src/pages/features/investors.jsx:78
 msgid "Successful companies share regular updates with their stakeholders, holding themselves accountable"
 msgstr "Les entreprises qui réussissent partagent régulièrement des mises à jour avec leurs actionnaires"
@@ -1097,7 +1147,8 @@ msgstr "Les entreprises qui réussissent partagent régulièrement des mises à 
 msgid "Suggest changes"
 msgstr "Suggérer des changements"
 
-#: src/pages/features/esop.jsx:36 src/pages/features/esop.jsx:74
+#: src/pages/features/esop.jsx:36
+#: src/pages/features/esop.jsx:74
 msgid "Supports everything"
 msgstr "Tout est pris en charge"
 
@@ -1125,7 +1176,7 @@ msgstr "Équipe"
 msgid "Technical data"
 msgstr "Données Techniques"
 
-#: src/layouts/index.jsx:212
+#: src/layouts/index.jsx:215
 msgid "Terms of Service"
 msgstr "Conditions d’utilisation"
 
@@ -1133,7 +1184,8 @@ msgstr "Conditions d’utilisation"
 msgid "The Ledgy Blog"
 msgstr "Le Blog Ledgy"
 
-#: src/layouts/index.jsx:380 src/pages/index.jsx:19
+#: src/layouts/index.jsx:383
+#: src/pages/index.jsx:19
 msgid "The New Standard in Equity Management"
 msgstr "Le nouveau standard en gestion d’actions"
 
@@ -1193,7 +1245,8 @@ msgstr "Suis de les exercices, les résiliations et les expirations"
 msgid "Track your valuations and understand the history in terms of percentage and number of shares"
 msgstr "Suis tes évaluations et comprends l’historique en termes de pourcentage et de nombre d’actions"
 
-#: src/pages/features/captable.jsx:41 src/pages/features/captable.jsx:76
+#: src/pages/features/captable.jsx:41
+#: src/pages/features/captable.jsx:76
 msgid "Transaction-based"
 msgstr "Basé sur les transactions"
 
@@ -1217,11 +1270,8 @@ msgstr "Fais confiance à ton cap table"
 msgid "Try 30 days free"
 msgstr "30 jours gratuits"
 
-#: src/layouts/index.jsx:89
-msgid "Try Ledgy now for free"
-msgstr "Essaye Ledgy maintenant gratuitement"
-
-#: src/pages/pricing.jsx:81 src/pages/security.jsx:92
+#: src/pages/pricing.jsx:81
+#: src/pages/security.jsx:92
 msgid "Two-factor authentication"
 msgstr "Authentification à deux facteurs"
 
@@ -1369,11 +1419,15 @@ msgstr "et l’historique de changements simplifie la diligence raisonnable"
 msgid "and numbered shares are natively supported"
 msgstr "et les actions numérotées sont soutenues nativement"
 
+#: src/layouts/index.jsx:96
+msgid "and stay up-to-date with everything your start-up needs"
+msgstr ""
+
 #: src/pages/features/modeling.jsx:60
 msgid "by liquidation preferences"
 msgstr "préférences de liquidation"
 
-#: src/layouts/index.jsx:389
+#: src/layouts/index.jsx:392
 msgid "cap table, stock ledger, share register, startup, modeling, financing round, equity, esop, phantom, option plan, virtual, portfolio, reporting, investors"
 msgstr "cap table, registre d’actions, startup, modélisation, ronde de financement, levée de fonds, actions, esop, plan d’options, virtuel, portefeuille, reporting, investisseurs, plan d’options"
 
@@ -1401,7 +1455,8 @@ msgstr "modélisation d’une nouvelle ronde de financement, y compris les bille
 msgid "per stakeholder per month"
 msgstr "par stakeholder par mois"
 
-#: src/pages/features/captable.jsx:60 src/pages/features/esop.jsx:55
+#: src/pages/features/captable.jsx:60
+#: src/pages/features/esop.jsx:55
 msgid "save time and focus on what matters"
 msgstr "gagne du temps et concentre-toi sur ce qui compte"
 

--- a/src/locale/fr/messages.po
+++ b/src/locale/fr/messages.po
@@ -500,7 +500,7 @@ msgstr "Avec un nombre illimité de catégories d’actions, d’actions autodé
 
 #: src/pages/index.jsx:141
 msgid "Finally, I have a reliable overview of all our shares, employee grants, and their legal documents. So much better than the Excel I used before."
-msgstr "Enfin, j‘ai une vue d‘ensemble fiable de toutes nos actions, des attributions aux employés et de leurs documents juridiques. Tellement mieux que l‘Excel que j‘utilisais avant."
+msgstr "Enfin, j’ai une vue d’ensemble fiable de toutes nos actions, des attributions aux employés et de leurs documents juridiques. Tellement mieux que l’Excel que j’utilisais avant."
 
 #: src/pages/pricing.jsx:19 src/pages/pricing.jsx:31 src/pages/pricing.jsx:42
 msgid "Financing round modeling"
@@ -615,7 +615,7 @@ msgstr "Comment nous protégeons tes données personnelles"
 
 #: src/pages/index.jsx:130
 msgid "I needed exactly that. Every founder should use Ledgy’s modeling tools for financing rounds!"
-msgstr "C‘est exactement ce dont j‘avais besoin. Tous les fondateurs devraient utiliser les outils de modélisation de Ledgy pour leurs levées de fonds!"
+msgstr "C’est exactement ce dont j’avais besoin. Tous les fondateurs devraient utiliser les outils de modélisation de Ledgy pour leurs levées de fonds!"
 
 #: src/pages/privacy.jsx:83
 msgid "Identity and contact data"
@@ -1079,7 +1079,7 @@ msgstr "Personnalise tes rapports selon tes besoins avec l’éditeur de texte"
 
 #: src/components/NewsletterForm.jsx:56
 msgid "Subscribe"
-msgstr "S'abonner"
+msgstr "S’abonner"
 
 #: src/layouts/index.jsx:98
 msgid "Subscribe to the newsletter"
@@ -1347,7 +1347,7 @@ msgstr "Yoko est diplômée de l’ETH Zürich et d’Oxford et a été préside
 
 #: src/pages/pricing.jsx:185
 msgid "You get a <0>20% discount</0> on Premium if your startup helps reducing carbon emissions.<1/><2>Write us</2> about your impact to see if you qualify."
-msgstr "Tu bénéficies d'un <0>rabais de 20 %</0> sur Premium si ta startup contribue à réduire les émissions de carbone.<1/><2>Écris-nous</2> au sujet de ton impact pour voir si tu es admissible."
+msgstr "Tu bénéficies d’un <0>rabais de 20 %</0> sur Premium si ta startup contribue à réduire les émissions de carbone.<1/><2>Écris-nous</2> au sujet de ton impact pour voir si tu es admissible."
 
 #: src/components/SecurityRow.jsx:31
 msgid "Your data is safe with us"

--- a/src/locale/fr/messages.po
+++ b/src/locale/fr/messages.po
@@ -1430,6 +1430,10 @@ msgstr "préférences de liquidation"
 msgid "cap table, stock ledger, share register, startup, modeling, financing round, equity, esop, phantom, option plan, virtual, portfolio, reporting, investors"
 msgstr "cap table, registre d’actions, startup, modélisation, ronde de financement, levée de fonds, actions, esop, plan d’options, virtuel, portefeuille, reporting, investisseurs, plan d’options"
 
+#: src/layouts/index.jsx:94
+msgid "for monthly updates on new features and start-up resources"
+msgstr ""
+
 #: src/pages/pricing.jsx:38
 msgid "free"
 msgstr "gratuit"

--- a/src/locale/fr/messages.po
+++ b/src/locale/fr/messages.po
@@ -50,7 +50,7 @@ msgstr "Un certificat de chaque document est automatiquement stocké sur la bitc
 msgid "A stakeholder is any holder of shares, (phantom) options, warrants, or convertibles.<0/>It does not include the company treasury or incentive pools."
 msgstr "Un stakeholder est tout détenteur d’actions, d’options (virtuelles), warrants ou de billets convertibles.<0/>Il n’inclut pas la société elle-même ni les pools d’options."
 
-#: src/layouts/index.jsx:113
+#: src/layouts/index.jsx:111
 #: src/pages/about-us.jsx:17
 #: src/pages/about-us.jsx:25
 msgid "About us"
@@ -203,8 +203,8 @@ msgid "Blockchain notary"
 msgstr "Notaire Blockchain"
 
 #: src/layouts/index.jsx:65
-#: src/layouts/index.jsx:116
-#: src/layouts/index.jsx:156
+#: src/layouts/index.jsx:114
+#: src/layouts/index.jsx:154
 #: src/pages/blog.jsx:61
 msgid "Blog"
 msgstr "Blog"
@@ -237,7 +237,7 @@ msgstr "Options d’entrée en bloc"
 msgid "Calculates waterfall analysis of liquidation preferences across all rounds"
 msgstr "Calcule l’analyse en cascade des préférences de liquidation à travers toutes les levées de fonds"
 
-#: src/layouts/index.jsx:187
+#: src/layouts/index.jsx:185
 msgid "Cap Table"
 msgstr "Cap Table"
 
@@ -254,7 +254,7 @@ msgstr "Cap table pendant la levée de fonds"
 msgid "Cap table management"
 msgstr "Gestion du cap table"
 
-#: src/layouts/index.jsx:125
+#: src/layouts/index.jsx:123
 msgid "Career"
 msgstr "Carrière"
 
@@ -272,7 +272,7 @@ msgstr "Codant depuis le lycée, Timo a obtenu un prix pour le meilleur mémoire
 msgid "Collaboration & Due Diligence"
 msgstr "Collaboration et diligence raisonnable"
 
-#: src/layouts/index.jsx:108
+#: src/layouts/index.jsx:106
 msgid "Company"
 msgstr "Société"
 
@@ -295,7 +295,7 @@ msgstr "Historique complet des transactions"
 msgid "Contact"
 msgstr "Contact"
 
-#: src/layouts/index.jsx:128
+#: src/layouts/index.jsx:126
 msgid "Contact & Imprint"
 msgstr "Contact & Mentions légales"
 
@@ -312,8 +312,8 @@ msgstr "Contactez-nous"
 msgid "Content-Security-Policy"
 msgstr "Politique de sécurité du contenu"
 
-#: src/pages/subscribed.jsx:44
-msgid "Continue to site"
+#: src/pages/subscribed.jsx:40
+msgid "Continue exploring"
 msgstr ""
 
 #: src/pages/features/modeling.jsx:168
@@ -332,7 +332,7 @@ msgstr "Convertir en transactions"
 msgid "Convertibles"
 msgstr "Décapotables"
 
-#: src/layouts/index.jsx:221
+#: src/layouts/index.jsx:219
 msgid "Cookie Policy"
 msgstr "Politique de Cookies"
 
@@ -407,7 +407,7 @@ msgstr "Ta startup contribue-t-elle à la lutte contre le changement climatique?
 msgid "Download holding confirmations with a single click"
 msgstr "Télécharge les confirmations de possession d’un simple clic"
 
-#: src/layouts/index.jsx:196
+#: src/layouts/index.jsx:194
 msgid "Due Diligence"
 msgstr "Diligence raisonnable"
 
@@ -443,7 +443,7 @@ msgstr "Signatures électroniques<0/>"
 msgid "Email notification about upcoming vesting event"
 msgstr "Notification par e-mail d’évènement de complétion de vesting imminent"
 
-#: src/layouts/index.jsx:193
+#: src/layouts/index.jsx:191
 msgid "Employee Incentives"
 msgstr "Participation des employés"
 
@@ -508,12 +508,12 @@ msgstr "Chaque entreprise a des indicateurs de performance clés, et les investi
 msgid "Exit modeling"
 msgstr "Modélisation de stratégie de sortie"
 
-#: src/layouts/index.jsx:144
+#: src/layouts/index.jsx:142
 msgid "FAQ"
 msgstr "FAQ"
 
 #: src/layouts/index.jsx:59
-#: src/layouts/index.jsx:184
+#: src/layouts/index.jsx:182
 #: src/pages/features/captable.jsx:21
 #: src/pages/features/collaboration.jsx:21
 #: src/pages/features/esop.jsx:16
@@ -551,7 +551,7 @@ msgstr "Pour une meilleure protection des comptes. Et notre implémentation est 
 msgid "Founder of Meisser Economics, Bitcoin Association Switzerland, and Wuala"
 msgstr "Fondateur de Meisser Economics, Bitcoin Association Switzerland, et Wuala"
 
-#: src/layouts/index.jsx:224
+#: src/layouts/index.jsx:222
 msgid "GDPR"
 msgstr "RGPD"
 
@@ -589,15 +589,15 @@ msgstr "Effectue les bons calculs"
 msgid "Get your cap table and employee participation plans right, from the beginning. Make your financing rounds a success and engage your investors and employees. Know your data is safe and compliant."
 msgstr "Bien comprendre ton cap table et tes plans d’actionnariat, dès le début. Fais de tes levées de fond un succès et mobilise tes investisseurs et tes employés. Sois sûr que tes données soient en sécurité."
 
-#: src/layouts/index.jsx:384
+#: src/layouts/index.jsx:382
 msgid "Get your cap table and employee participation plans right, from the beginning. Make your financing rounds a success and engage your investors and employees. Know your data is safe and compliant. Try now for free!"
 msgstr "Configure ton cap table et tes plans d’actionnariat des employés correctement, dès le début. Fais de tes levées de fonds un succès et mobilise tes investisseurs et tes employés. Aies la tranquillité d’esprit que tes données sont sûres et conformes. Essaye maintenant gratuitement !"
 
-#: src/layouts/index.jsx:141
+#: src/layouts/index.jsx:139
 msgid "Getting Started"
 msgstr "Commencer"
 
-#: src/pages/subscribed.jsx:47
+#: src/pages/subscribed.jsx:43
 msgid "Go to Ledgy app"
 msgstr ""
 
@@ -622,7 +622,7 @@ msgstr "Les en-têtes HTTP empêchent les scripts intersites et l’injection de
 msgid "Healthcare & technology venture capital since 2001"
 msgstr "Capital de risque dans le domaine de la santé et de la technologie depuis 2001"
 
-#: src/layouts/index.jsx:136
+#: src/layouts/index.jsx:134
 msgid "Help"
 msgstr "Aide"
 
@@ -695,7 +695,7 @@ msgstr "Relations investisseurs et portfolio"
 msgid "Investor portfolio"
 msgstr "Portefeuille d’investisseurs"
 
-#: src/layouts/index.jsx:199
+#: src/layouts/index.jsx:197
 msgid "Investors"
 msgstr "Investisseurs"
 
@@ -743,7 +743,7 @@ msgstr "Indicateurs clés de performance"
 msgid "Kpi chart"
 msgstr "Diagramme Kpi"
 
-#: src/layouts/index.jsx:256
+#: src/layouts/index.jsx:254
 msgid "Language"
 msgstr "Langue"
 
@@ -771,7 +771,7 @@ msgstr "Ledgy facilite la simulation d’un investissement avec une distribution
 msgid "Ledgy scales with your needs. Free for startups, powerful for grown-ups."
 msgstr "Ledgy s’adapte à tes besoins. Gratuit pour les startups, puissant pour les scale-ups."
 
-#: src/layouts/index.jsx:210
+#: src/layouts/index.jsx:208
 msgid "Legal"
 msgstr "Légal"
 
@@ -815,7 +815,7 @@ msgstr "Marius a une formation en informatique, est diplômé de l’Université
 msgid "Meet the team behind Ledgy that went out to help startups thrive. Learn more about the people who trust in us."
 msgstr "Rencontre l’équipe derrière Ledgy qui pour mission d’aider les startups à prospérer. En savoir plus sur les personnes qui nous font confiance."
 
-#: src/layouts/index.jsx:190
+#: src/layouts/index.jsx:188
 msgid "Modeling"
 msgstr "Modélisation"
 
@@ -900,7 +900,7 @@ msgid "Premium"
 msgstr "Premium"
 
 #: src/layouts/index.jsx:62
-#: src/layouts/index.jsx:202
+#: src/layouts/index.jsx:200
 #: src/pages/pricing.jsx:15
 #: src/pages/pricing.jsx:24
 msgid "Pricing"
@@ -910,13 +910,13 @@ msgstr "Tarifs"
 msgid "Priority support"
 msgstr "Support prioritaire"
 
-#: src/layouts/index.jsx:122
+#: src/layouts/index.jsx:120
 #: src/pages/privacy.jsx:21
 #: src/pages/privacy.jsx:29
 msgid "Privacy"
 msgstr "Confidentialité"
 
-#: src/layouts/index.jsx:218
+#: src/layouts/index.jsx:216
 msgid "Privacy Policy"
 msgstr "Politique de confidentialité"
 
@@ -933,7 +933,7 @@ msgstr "Confidentialité made in Europe. Parce que tes données ne doivent pas �
 msgid "Pro-rata distribution"
 msgstr "Distribution au prorata"
 
-#: src/layouts/index.jsx:179
+#: src/layouts/index.jsx:177
 msgid "Product"
 msgstr "Produit"
 
@@ -1036,7 +1036,7 @@ msgstr "Data room sécurisée"
 msgid "Secure data room, audit trail and read-only access for investors; save costly due diligence tools."
 msgstr "Data room sécurisée, piste d’audits et accès en lecture seule pour les investisseurs; économise sur les outils coûteux de diligence raisonnable."
 
-#: src/layouts/index.jsx:119
+#: src/layouts/index.jsx:117
 #: src/pages/privacy.jsx:109
 #: src/pages/security.jsx:25
 #: src/pages/security.jsx:33
@@ -1083,6 +1083,10 @@ msgstr "Partage tes scénarios au format pdf, y compris les évaluations de ton 
 msgid "Show cap table fully diluted"
 msgstr "Afficher le cap table entièrement dilué"
 
+#: src/layouts/index.jsx:77
+msgid "Sign up"
+msgstr ""
+
 #: src/pages/features/modeling.jsx:120
 msgid "Simulation settings"
 msgstr "Paramètres de simulation"
@@ -1127,12 +1131,11 @@ msgid "Style your reports to your needs with the rich-text editor"
 msgstr "Personnalise tes rapports selon tes besoins avec l’éditeur de texte"
 
 #: src/components/SignupForm.jsx:52
-#: src/layouts/index.jsx:78
 msgid "Subscribe"
 msgstr ""
 
-#: src/layouts/index.jsx:92
-msgid "Subscribe to our newsletter"
+#: src/layouts/index.jsx:90
+msgid "Subscribe to the newsletter"
 msgstr ""
 
 #: src/pages/subscribed.jsx:15
@@ -1176,7 +1179,7 @@ msgstr "Équipe"
 msgid "Technical data"
 msgstr "Données Techniques"
 
-#: src/layouts/index.jsx:215
+#: src/layouts/index.jsx:213
 msgid "Terms of Service"
 msgstr "Conditions d’utilisation"
 
@@ -1184,7 +1187,7 @@ msgstr "Conditions d’utilisation"
 msgid "The Ledgy Blog"
 msgstr "Le Blog Ledgy"
 
-#: src/layouts/index.jsx:383
+#: src/layouts/index.jsx:381
 #: src/pages/index.jsx:19
 msgid "The New Standard in Equity Management"
 msgstr "Le nouveau standard en gestion d’actions"
@@ -1419,15 +1422,11 @@ msgstr "et l’historique de changements simplifie la diligence raisonnable"
 msgid "and numbered shares are natively supported"
 msgstr "et les actions numérotées sont soutenues nativement"
 
-#: src/layouts/index.jsx:96
-msgid "and stay up-to-date with everything your start-up needs"
-msgstr ""
-
 #: src/pages/features/modeling.jsx:60
 msgid "by liquidation preferences"
 msgstr "préférences de liquidation"
 
-#: src/layouts/index.jsx:392
+#: src/layouts/index.jsx:390
 msgid "cap table, stock ledger, share register, startup, modeling, financing round, equity, esop, phantom, option plan, virtual, portfolio, reporting, investors"
 msgstr "cap table, registre d’actions, startup, modélisation, ronde de financement, levée de fonds, actions, esop, plan d’options, virtuel, portefeuille, reporting, investisseurs, plan d’options"
 

--- a/src/locale/fr/messages.po
+++ b/src/locale/fr/messages.po
@@ -4,7 +4,7 @@ msgstr ""
 "Mime-Version: 1.0\n"
 "Content-Type: text/plain; charset=utf-8\n"
 "Content-Transfer-Encoding: 8bit\n"
-"X-Generator: Poedit 2.2.3\n"
+"X-Generator: Poedit 2.2.1\n"
 "Language: fr\n"
 "Project-Id-Version: \n"
 "Report-Msgid-Bugs-To: \n"
@@ -14,19 +14,19 @@ msgstr ""
 "Plural-Forms: \n"
 "MIME-Version: 1.0\n"
 
-#: src/pages/pricing.jsx:15
+#: src/pages/pricing.jsx:19
 msgid "1 round, 1 scenario"
 msgstr "1 levée de fonds, 1 scénario"
 
-#: src/pages/pricing.jsx:16
+#: src/pages/pricing.jsx:20
 msgid "2 admins, stakeholder access"
 msgstr "2 admin, accès stakeholder"
 
-#: src/pages/pricing.jsx:83
+#: src/pages/pricing.jsx:87
 msgid "30-day trial"
-msgstr ""
+msgstr "30 jours d’essai"
 
-#: src/pages/pricing.jsx:28
+#: src/pages/pricing.jsx:32
 msgid "4 admins, view-only access"
 msgstr "4 admins, accès en vue seule"
 
@@ -46,19 +46,16 @@ msgstr "<0>View</0> Voir toutes les informations du cap table en mode lecture se
 msgid "A certificate of each document is automatically stored on the bitcoin blockchain when uploading"
 msgstr "Un certificat de chaque document est automatiquement stocké sur la bitcoin blockchain lors du téléchargement"
 
-#: src/pages/pricing.jsx:161
+#: src/pages/pricing.jsx:165
 msgid "A stakeholder is any holder of shares, (phantom) options, warrants, or convertibles.<0/>It does not include the company treasury or incentive pools."
 msgstr "Un stakeholder est tout détenteur d’actions, d’options (virtuelles), warrants ou de billets convertibles.<0/>Il n’inclut pas la société elle-même ni les pools d’options."
 
-#: src/layouts/index.jsx:115
-#: src/pages/about-us.jsx:17
+#: src/layouts/index.jsx:119 src/pages/about-us.jsx:17
 #: src/pages/about-us.jsx:25
 msgid "About us"
 msgstr "À propos de nous"
 
-#: src/pages/pricing.jsx:16
-#: src/pages/pricing.jsx:28
-#: src/pages/pricing.jsx:39
+#: src/pages/pricing.jsx:20 src/pages/pricing.jsx:32 src/pages/pricing.jsx:43
 msgid "Access rights"
 msgstr "Droits d’accès"
 
@@ -90,12 +87,11 @@ msgstr "Ajouter un vesting"
 msgid "Add vesting or inverse vesting to any transaction"
 msgstr "Ajouter un vesting à toute transaction"
 
-#: src/pages/features/modeling.jsx:53
-#: src/pages/features/modeling.jsx:111
+#: src/pages/features/modeling.jsx:53 src/pages/features/modeling.jsx:111
 msgid "Adjust your simulations"
 msgstr "Ajuste tes simulations"
 
-#: src/pages/pricing.jsx:36
+#: src/pages/pricing.jsx:40
 msgid "All Premium features"
 msgstr "Les fonctions Premium"
 
@@ -103,12 +99,11 @@ msgstr "Les fonctions Premium"
 msgid "All data is stored at an <0>independent provider</0> in France"
 msgstr "Toutes les données sont stockées chez un prestataire <0>indépendant </0> en France"
 
-#: src/pages/pricing.jsx:25
+#: src/pages/pricing.jsx:29
 msgid "All standard features"
-msgstr ""
+msgstr "Les fonctions standard"
 
-#: src/components/Feature.jsx:89
-#: src/pages/features.jsx:23
+#: src/components/Feature.jsx:89 src/pages/features.jsx:23
 msgid "All you need in one place"
 msgstr "Tout ce dont tu as besoin au même endroit"
 
@@ -124,8 +119,7 @@ msgstr "Portefeuille toujours à jour, géré par tes startups"
 msgid "Analyze it by stakeholder, share class, stakeholder group and view it with all, outstanding or diluted shares"
 msgstr "Analyse-le par actionnaire, catégorie d’actions, groupe d’actionnaires et visualise-le avec toutes les actions en circulation ou diluées"
 
-#: src/pages/features/esop.jsx:92
-#: src/pages/pricing.jsx:26
+#: src/pages/features/esop.jsx:92 src/pages/pricing.jsx:30
 msgid "Any vesting schedule"
 msgstr "Tout calendrier de vesting"
 
@@ -149,8 +143,7 @@ msgstr "Chez Ledgy, nous prenons ta sécurité au sérieux. Des mots de passe s�
 msgid "Attach doc to transaction"
 msgstr "Joindre le document à la transaction"
 
-#: src/pages/features/captable.jsx:53
-#: src/pages/features/captable.jsx:136
+#: src/pages/features/captable.jsx:53 src/pages/features/captable.jsx:136
 msgid "Attach documents"
 msgstr "Joins des documents"
 
@@ -202,14 +195,12 @@ msgstr "Certification Blockchain"
 msgid "Blockchain notary"
 msgstr "Notaire Blockchain"
 
-#: src/layouts/index.jsx:65
-#: src/layouts/index.jsx:118
-#: src/layouts/index.jsx:158
+#: src/layouts/index.jsx:65 src/layouts/index.jsx:122 src/layouts/index.jsx:162
 #: src/pages/blog.jsx:61
 msgid "Blog"
 msgstr "Blog"
 
-#: src/pages/pricing.jsx:32
+#: src/pages/pricing.jsx:36
 msgid "Breakpoint & exit analyses"
 msgstr "Analyses des points d’arrêt et de sortie"
 
@@ -237,12 +228,11 @@ msgstr "Options d’entrée en bloc"
 msgid "Calculates waterfall analysis of liquidation preferences across all rounds"
 msgstr "Calcule l’analyse en cascade des préférences de liquidation à travers toutes les levées de fonds"
 
-#: src/layouts/index.jsx:189
+#: src/layouts/index.jsx:193
 msgid "Cap Table"
 msgstr "Cap Table"
 
-#: src/components/Feature.jsx:99
-#: src/pages/features.jsx:58
+#: src/components/Feature.jsx:99 src/pages/features.jsx:58
 msgid "Cap Table Management"
 msgstr "Gestion du cap table"
 
@@ -250,11 +240,11 @@ msgstr "Gestion du cap table"
 msgid "Cap table during round modeling"
 msgstr "Cap table pendant la levée de fonds"
 
-#: src/pages/pricing.jsx:13
+#: src/pages/pricing.jsx:17
 msgid "Cap table management"
 msgstr "Gestion du cap table"
 
-#: src/layouts/index.jsx:127
+#: src/layouts/index.jsx:131
 msgid "Career"
 msgstr "Carrière"
 
@@ -266,18 +256,20 @@ msgstr "Choisis de n’afficher que les pools ou la vue détaillée avec les par
 msgid "Coding since high school, Timo got an award for the best master thesis in computer science and worked one year as a computer engineer in robotics"
 msgstr "Codant depuis le lycée, Timo a obtenu un prix pour le meilleur mémoire de maîtrise en informatique et a travaillé un an comme ingénieur en robotique"
 
-#: src/components/Feature.jsx:101
-#: src/pages/features/collaboration.jsx:20
+#: src/components/Feature.jsx:101 src/pages/features/collaboration.jsx:20
 #: src/pages/features.jsx:104
 msgid "Collaboration & Due Diligence"
 msgstr "Collaboration et diligence raisonnable"
 
-#: src/layouts/index.jsx:110
+#: src/pages/pricing.jsx:12
+msgid "Coming soon"
+msgstr "Prochainement"
+
+#: src/layouts/index.jsx:114
 msgid "Company"
 msgstr "Société"
 
-#: src/pages/features/modeling.jsx:47
-#: src/pages/features/modeling.jsx:95
+#: src/pages/features/modeling.jsx:47 src/pages/features/modeling.jsx:95
 #: src/pages/features/modeling.jsx:105
 msgid "Compare and share scenarios"
 msgstr "Compare et partage des scénarios"
@@ -290,12 +282,11 @@ msgstr "Complète ton portefeuille"
 msgid "Comprehensive transaction history"
 msgstr "Historique complet des transactions"
 
-#: src/pages/contact.jsx:10
-#: src/pages/contact.jsx:74
+#: src/pages/contact.jsx:10 src/pages/contact.jsx:74
 msgid "Contact"
 msgstr "Contact"
 
-#: src/layouts/index.jsx:130
+#: src/layouts/index.jsx:134
 msgid "Contact & Imprint"
 msgstr "Contact & Mentions légales"
 
@@ -303,18 +294,13 @@ msgstr "Contact & Mentions légales"
 msgid "Contact data, usage statistics, and technical data"
 msgstr "Données de contact, statistiques d’utilisation et données techniques"
 
-#: src/pages/pricing.jsx:152
-#: src/pages/pricing.jsx:154
+#: src/pages/pricing.jsx:156 src/pages/pricing.jsx:158
 msgid "Contact us"
 msgstr "Contactez-nous"
 
 #: src/pages/security.jsx:142
 msgid "Content-Security-Policy"
 msgstr "Politique de sécurité du contenu"
-
-#: src/pages/subscribed.jsx:40
-msgid "Continue exploring"
-msgstr ""
 
 #: src/pages/features/modeling.jsx:168
 msgid "Convert financing round"
@@ -328,11 +314,11 @@ msgstr "Convertis le scénario final en seulement deux clics"
 msgid "Convert to transactions"
 msgstr "Convertir en transactions"
 
-#: src/pages/pricing.jsx:20
+#: src/pages/pricing.jsx:24
 msgid "Convertibles"
 msgstr "Décapotables"
 
-#: src/layouts/index.jsx:223
+#: src/layouts/index.jsx:227
 msgid "Cookie Policy"
 msgstr "Politique de Cookies"
 
@@ -364,12 +350,11 @@ msgstr "Data room, piste d’audits et accès en lecture seule pour les investis
 msgid "Digital entrepreneur and investor. Security, crypto & privacy expert"
 msgstr "Entrepreneur et investisseur en technologies digitales. Expert en sécurité et cryptographie"
 
-#: src/pages/features/esop.jsx:137
-#: src/pages/features/modeling.jsx:140
+#: src/pages/features/esop.jsx:137 src/pages/features/modeling.jsx:140
 msgid "Diluted cap table"
 msgstr "Cap table dilué"
 
-#: src/pages/pricing.jsx:169
+#: src/pages/pricing.jsx:173
 msgid "Discover all features"
 msgstr "Découvre les fonctionnalités"
 
@@ -389,17 +374,15 @@ msgstr "Liens aux documents"
 msgid "Document management"
 msgstr "Gestion des documents"
 
-#: src/pages/pricing.jsx:17
-#: src/pages/pricing.jsx:29
-#: src/pages/pricing.jsx:40
+#: src/pages/pricing.jsx:21 src/pages/pricing.jsx:33 src/pages/pricing.jsx:44
 msgid "Document storage"
 msgstr "Stockage des documents"
 
-#: src/pages/pricing.jsx:43
+#: src/pages/pricing.jsx:47
 msgid "Document workflow <0/>"
-msgstr ""
+msgstr "Workflow de documents <0/>"
 
-#: src/pages/pricing.jsx:175
+#: src/pages/pricing.jsx:179
 msgid "Does your startup tackle the climate crisis?"
 msgstr "Ta startup contribue-t-elle à la lutte contre le changement climatique?"
 
@@ -407,7 +390,7 @@ msgstr "Ta startup contribue-t-elle à la lutte contre le changement climatique?
 msgid "Download holding confirmations with a single click"
 msgstr "Télécharge les confirmations de possession d’un simple clic"
 
-#: src/layouts/index.jsx:198
+#: src/layouts/index.jsx:202
 msgid "Due Diligence"
 msgstr "Diligence raisonnable"
 
@@ -435,20 +418,19 @@ msgstr "Protection des données de l’UE"
 msgid "Edit log"
 msgstr "Modifier l’historique d’édition"
 
-#: src/pages/pricing.jsx:49
+#: src/pages/pricing.jsx:53
 msgid "Electronic signatures <0/>"
-msgstr ""
+msgstr "Signatures électroniques <0/>"
 
 #: src/pages/features/esop.jsx:123
 msgid "Email notification about upcoming vesting event"
 msgstr "Notification par e-mail d’évènement de complétion de vesting imminent"
 
-#: src/layouts/index.jsx:195
+#: src/layouts/index.jsx:199
 msgid "Employee Incentives"
 msgstr "Participation des employés"
 
-#: src/components/Feature.jsx:98
-#: src/pages/features/esop.jsx:25
+#: src/components/Feature.jsx:98 src/pages/features/esop.jsx:25
 #: src/pages/features.jsx:33
 msgid "Employee Participation Plans"
 msgstr "Plans de participation des employés"
@@ -457,8 +439,7 @@ msgstr "Plans de participation des employés"
 msgid "Encrypted connection"
 msgstr "Connexion cryptée"
 
-#: src/pages/features/esop.jsx:48
-#: src/pages/features/esop.jsx:109
+#: src/pages/features/esop.jsx:48 src/pages/features/esop.jsx:109
 msgid "Engage your employees"
 msgstr "Mobilise tes employés"
 
@@ -466,7 +447,7 @@ msgstr "Mobilise tes employés"
 msgid "Enjoy the highest security standards"
 msgstr "Bénéficie des plus hauts standards de sécurité"
 
-#: src/components/NewsletterForm.jsx:43
+#: src/components/NewsletterForm.jsx:47
 msgid "Enter your email…"
 msgstr "Entre ton adresse email…"
 
@@ -478,8 +459,7 @@ msgstr "Entrepreneur, business angel, fondateur de Doodle.com"
 msgid "Entrepreneur, technologist, founder of Doodle.com"
 msgstr "Entrepreneur, technologist, fondateur de Doodle.com"
 
-#: src/pages/privacy.jsx:77
-#: src/pages/privacy.jsx:129
+#: src/pages/privacy.jsx:77 src/pages/privacy.jsx:129
 msgid "Equity data"
 msgstr "Données sur les capitaux propres"
 
@@ -487,7 +467,7 @@ msgstr "Données sur les capitaux propres"
 msgid "Equity data is too important to be accidentally tweaked in a spreadsheet"
 msgstr "Les données sur les actions sont trop importantes pour être modifiées accidentellement dans une feuille de calcul"
 
-#: src/pages/pricing.jsx:26
+#: src/pages/pricing.jsx:30
 msgid "Equity plan management"
 msgstr "Plan d’actionnariat"
 
@@ -499,23 +479,18 @@ msgstr "La symbiose européenne entre les fonds de capital-risque et le réseau 
 msgid "Every company has KPIs, and investors love seeing them in real-time"
 msgstr "Chaque entreprise a des indicateurs de performance clés, et les investisseurs adorent les voir en temps réel"
 
-#: src/pages/features/modeling.jsx:173
-#: src/pages/features/modeling.jsx:186
+#: src/pages/features/modeling.jsx:173 src/pages/features/modeling.jsx:186
 msgid "Exit modeling"
 msgstr "Modélisation de stratégie de sortie"
 
-#: src/layouts/index.jsx:146
+#: src/layouts/index.jsx:150
 msgid "FAQ"
 msgstr "FAQ"
 
-#: src/layouts/index.jsx:59
-#: src/layouts/index.jsx:186
-#: src/pages/features/captable.jsx:21
-#: src/pages/features/collaboration.jsx:21
-#: src/pages/features/esop.jsx:16
-#: src/pages/features/investors.jsx:21
-#: src/pages/features/modeling.jsx:21
-#: src/pages/features.jsx:14
+#: src/layouts/index.jsx:59 src/layouts/index.jsx:190
+#: src/pages/features/captable.jsx:21 src/pages/features/collaboration.jsx:21
+#: src/pages/features/esop.jsx:16 src/pages/features/investors.jsx:21
+#: src/pages/features/modeling.jsx:21 src/pages/features.jsx:14
 msgid "Features"
 msgstr "Fonctionalités"
 
@@ -527,9 +502,7 @@ msgstr "Avec un nombre illimité de catégories d’actions, d’actions autodé
 msgid "Finally, I have a reliable overview of all our shares, employee grants, and their legal documents. So much better than the Excel I used before."
 msgstr "Enfin, j‘ai une vue d‘ensemble fiable de toutes nos actions, des attributions aux employés et de leurs documents juridiques. Tellement mieux que l‘Excel que j‘utilisais avant."
 
-#: src/pages/pricing.jsx:15
-#: src/pages/pricing.jsx:27
-#: src/pages/pricing.jsx:38
+#: src/pages/pricing.jsx:19 src/pages/pricing.jsx:31 src/pages/pricing.jsx:42
 msgid "Financing round modeling"
 msgstr "Modélisation"
 
@@ -549,11 +522,11 @@ msgstr "Pour une meilleure protection des comptes. Et notre implémentation est 
 msgid "Founder of Meisser Economics, Bitcoin Association Switzerland, and Wuala"
 msgstr "Fondateur de Meisser Economics, Bitcoin Association Switzerland, et Wuala"
 
-#: src/pages/pricing.jsx:138
+#: src/pages/pricing.jsx:142
 msgid "Free"
-msgstr ""
+msgstr "Gratuit"
 
-#: src/layouts/index.jsx:226
+#: src/layouts/index.jsx:230
 msgid "GDPR"
 msgstr "RGPD"
 
@@ -573,7 +546,7 @@ msgstr "Sois informé des événements importants liés au vesting et à l’exp
 msgid "Get notified two weeks before a cliff or vesting ends or a grant expires to not miss using your participation plan for engaging your employees"
 msgstr "Sois avisé deux semaines avant la fin d’une période de vesting ou de l’expiration d’options"
 
-#: src/pages/pricing.jsx:140
+#: src/pages/pricing.jsx:144
 msgid "Get started"
 msgstr "Commencer"
 
@@ -581,8 +554,7 @@ msgstr "Commencer"
 msgid "Get started in minutes with the copy-paste spreadsheet importer"
 msgstr "Démarre en quelques minutes avec un simple copier-coller dans l’importateur de fichiers excel"
 
-#: src/pages/features/modeling.jsx:41
-#: src/pages/features/modeling.jsx:76
+#: src/pages/features/modeling.jsx:41 src/pages/features/modeling.jsx:76
 #: src/pages/features/modeling.jsx:88
 msgid "Get the calculations right"
 msgstr "Effectue les bons calculs"
@@ -591,17 +563,13 @@ msgstr "Effectue les bons calculs"
 msgid "Get your cap table and employee participation plans right, from the beginning. Make your financing rounds a success and engage your investors and employees. Know your data is safe and compliant."
 msgstr "Bien comprendre ton cap table et tes plans d’actionnariat, dès le début. Fais de tes levées de fond un succès et mobilise tes investisseurs et tes employés. Sois sûr que tes données soient en sécurité."
 
-#: src/layouts/index.jsx:386
+#: src/layouts/index.jsx:390
 msgid "Get your cap table and employee participation plans right, from the beginning. Make your financing rounds a success and engage your investors and employees. Know your data is safe and compliant. Try now for free!"
 msgstr "Configure ton cap table et tes plans d’actionnariat des employés correctement, dès le début. Fais de tes levées de fonds un succès et mobilise tes investisseurs et tes employés. Aies la tranquillité d’esprit que tes données sont sûres et conformes. Essaye maintenant gratuitement !"
 
-#: src/layouts/index.jsx:143
+#: src/layouts/index.jsx:147
 msgid "Getting Started"
 msgstr "Commencer"
-
-#: src/pages/subscribed.jsx:43
-msgid "Go to Ledgy app"
-msgstr ""
 
 #: src/pages/features/esop.jsx:80
 msgid "Grant options, phantom options, warrants or add inverse vesting to stock transactions"
@@ -624,7 +592,7 @@ msgstr "Les en-têtes HTTP empêchent les scripts intersites et l’injection de
 msgid "Healthcare & technology venture capital since 2001"
 msgstr "Capital de risque dans le domaine de la santé et de la technologie depuis 2001"
 
-#: src/layouts/index.jsx:138
+#: src/layouts/index.jsx:142
 msgid "Help"
 msgstr "Aide"
 
@@ -637,8 +605,7 @@ msgid "Holding confirmation"
 msgstr "Confirmation de possession"
 
 #: src/pages/features/collaboration.jsx:59
-#: src/pages/features/collaboration.jsx:169
-#: src/pages/pricing.jsx:18
+#: src/pages/features/collaboration.jsx:169 src/pages/pricing.jsx:22
 msgid "Holding confirmations"
 msgstr "Confirmations de possession"
 
@@ -686,10 +653,8 @@ msgstr "Cap table intuitif, juridiquement valide et exempt d’erreurs dès le d
 msgid "Investor & consultant (Farmy.ch, Flatfox.ch), founder of Students.ch"
 msgstr "Investisseur & consultant (Farmy.ch, Flatfox.ch), fondateur de Students.ch"
 
-#: src/components/Feature.jsx:102
-#: src/pages/features/investors.jsx:20
-#: src/pages/features/investors.jsx:30
-#: src/pages/features.jsx:126
+#: src/components/Feature.jsx:102 src/pages/features/investors.jsx:20
+#: src/pages/features/investors.jsx:30 src/pages/features.jsx:126
 msgid "Investor Relations & Portfolio"
 msgstr "Relations investisseurs et portfolio"
 
@@ -697,7 +662,7 @@ msgstr "Relations investisseurs et portfolio"
 msgid "Investor portfolio"
 msgstr "Portefeuille d’investisseurs"
 
-#: src/layouts/index.jsx:201
+#: src/layouts/index.jsx:205
 msgid "Investors"
 msgstr "Investisseurs"
 
@@ -745,7 +710,7 @@ msgstr "Indicateurs clés de performance"
 msgid "Kpi chart"
 msgstr "Diagramme Kpi"
 
-#: src/layouts/index.jsx:258
+#: src/layouts/index.jsx:262
 msgid "Language"
 msgstr "Langue"
 
@@ -769,11 +734,11 @@ msgstr "En savoir plus sur la gestion documentaire"
 msgid "Ledgy makes it easy to simulate an investment with a pro-rata distribution"
 msgstr "Ledgy facilite la simulation d’un investissement avec une distribution au prorata"
 
-#: src/pages/pricing.jsx:118
+#: src/pages/pricing.jsx:122
 msgid "Ledgy scales with your needs. Free for startups, powerful for grown-ups."
 msgstr "Ledgy s’adapte à tes besoins. Gratuit pour les startups, puissant pour les scale-ups."
 
-#: src/layouts/index.jsx:212
+#: src/layouts/index.jsx:216
 msgid "Legal"
 msgstr "Légal"
 
@@ -785,11 +750,11 @@ msgstr "Les documents juridiques associés aux transactions à portée de main"
 msgid "Let’s Get In Touch"
 msgstr "Prenons contact"
 
-#: src/pages/pricing.jsx:31
+#: src/pages/pricing.jsx:35
 msgid "Liquidation preferences"
 msgstr "Préférences de liquidation"
 
-#: src/layouts/index.jsx:74
+#: src/layouts/index.jsx:78
 msgid "Log In"
 msgstr "Connexion"
 
@@ -817,11 +782,11 @@ msgstr "Marius a une formation en informatique, est diplômé de l’Université
 msgid "Meet the team behind Ledgy that went out to help startups thrive. Learn more about the people who trust in us."
 msgstr "Rencontre l’équipe derrière Ledgy qui pour mission d’aider les startups à prospérer. En savoir plus sur les personnes qui nous font confiance."
 
-#: src/layouts/index.jsx:192
+#: src/layouts/index.jsx:196
 msgid "Modeling"
 msgstr "Modélisation"
 
-#: src/pages/pricing.jsx:27
+#: src/pages/pricing.jsx:31
 msgid "Multiple rounds, 3 scenarios"
 msgstr "3 scénarios"
 
@@ -833,7 +798,7 @@ msgstr "Nom, adresse email, adresse et tout autre renseignement que tu nous four
 msgid "Nobody has any access to the equity data you provide. They are safely stored at a secure data center in France. Your stakeholders have no access and don’t get emails before you explicitly invite them"
 msgstr "Personne n’a accès aux données sur les actions que tu fournis. Ils sont stockés en toute sécurité dans un centre de données sécurisé en France. Tes actionnaires n’ont pas accès et ne reçoivent pas de courriels avant que te ne les aies explicitement invités"
 
-#: src/pages/pricing.jsx:30
+#: src/pages/pricing.jsx:34
 msgid "Notifications"
 msgstr "Notifications"
 
@@ -849,7 +814,7 @@ msgstr "La cohérence des numéros est vérifiée, ce qui te donne la tranquilli
 msgid "One of the most active Swiss early-stage angel investors"
 msgstr "L’un des angel investors suisses les plus actifs en early-stage"
 
-#: src/components/NewsletterForm.jsx:56
+#: src/components/NewsletterForm.jsx:60
 msgid "Oops. This email address is invalid."
 msgstr "Oups. Cette adresse e-mail n’est pas valide."
 
@@ -869,7 +834,7 @@ msgstr "Cryptage du mot de passe"
 msgid "Peer-reviewed code"
 msgstr "Code révisé par l’équipe"
 
-#: src/pages/pricing.jsx:37
+#: src/pages/pricing.jsx:41
 msgid "Phone & chat, onboarding"
 msgstr "Téléphone et chat"
 
@@ -881,9 +846,8 @@ msgstr "Joue avec les paramètres qui favorisent différents actionnaires, vois 
 msgid "Pooled investment"
 msgstr "Investissement en fond commun"
 
-#: src/pages/features/captable.jsx:47
-#: src/pages/features/captable.jsx:117
-#: src/pages/pricing.jsx:19
+#: src/pages/features/captable.jsx:47 src/pages/features/captable.jsx:117
+#: src/pages/pricing.jsx:23
 msgid "Pooled investments"
 msgstr "Investissement en fond commun"
 
@@ -891,30 +855,25 @@ msgstr "Investissement en fond commun"
 msgid "Pooled investments are common in many countries, Ledgy helps you keep them organized"
 msgstr "Les placements collectifs en pool sont courants dans de nombreux pays, Ledgy t’aide à les garder organisés"
 
-#: src/pages/features/investors.jsx:59
-#: src/pages/features/investors.jsx:122
+#: src/pages/features/investors.jsx:59 src/pages/features/investors.jsx:122
 #: src/pages/features/investors.jsx:128
 msgid "Portfolio history"
 msgstr "Historique du portefeuille"
 
-#: src/layouts/index.jsx:62
-#: src/layouts/index.jsx:204
-#: src/pages/pricing.jsx:117
-#: src/pages/pricing.jsx:126
+#: src/layouts/index.jsx:62 src/layouts/index.jsx:208 src/pages/pricing.jsx:121
+#: src/pages/pricing.jsx:130
 msgid "Pricing"
 msgstr "Tarifs"
 
-#: src/pages/pricing.jsx:37
+#: src/pages/pricing.jsx:41
 msgid "Priority support"
 msgstr "Support prioritaire"
 
-#: src/layouts/index.jsx:124
-#: src/pages/privacy.jsx:21
-#: src/pages/privacy.jsx:29
+#: src/layouts/index.jsx:128 src/pages/privacy.jsx:21 src/pages/privacy.jsx:29
 msgid "Privacy"
 msgstr "Confidentialité"
 
-#: src/layouts/index.jsx:220
+#: src/layouts/index.jsx:224
 msgid "Privacy Policy"
 msgstr "Politique de confidentialité"
 
@@ -922,8 +881,7 @@ msgstr "Politique de confidentialité"
 msgid "Privacy made in Europe"
 msgstr "Privacy made in Europe"
 
-#: src/pages/privacy.jsx:22
-#: src/pages/privacy.jsx:45
+#: src/pages/privacy.jsx:22 src/pages/privacy.jsx:45
 msgid "Privacy made in Europe. Because your equity data is not for everyone."
 msgstr "Confidentialité made in Europe. Parce que tes données ne doivent pas être accessible à tout le monde."
 
@@ -931,12 +889,11 @@ msgstr "Confidentialité made in Europe. Parce que tes données ne doivent pas �
 msgid "Pro-rata distribution"
 msgstr "Distribution au prorata"
 
-#: src/layouts/index.jsx:181
+#: src/layouts/index.jsx:185
 msgid "Product"
 msgstr "Produit"
 
-#: src/pages/features/investors.jsx:53
-#: src/pages/features/investors.jsx:109
+#: src/pages/features/investors.jsx:53 src/pages/features/investors.jsx:109
 msgid "Professional portfolio"
 msgstr "Portefeuille professionnel"
 
@@ -960,8 +917,7 @@ msgstr "Accédez rapidement aux documents à travers les transactions qui y sont
 msgid "Quickly pull up legal documents by the information of their linked transactions"
 msgstr "Retrouve rapidement les documents juridiques par l’information de leurs transactions correspondantes"
 
-#: src/components/SecurityRow.jsx:22
-#: src/components/SecurityRow.jsx:37
+#: src/components/SecurityRow.jsx:22 src/components/SecurityRow.jsx:37
 #: src/pages/blog.jsx:49
 msgid "Read more"
 msgstr "Lire plus"
@@ -970,12 +926,11 @@ msgstr "Lire plus"
 msgid "Record of edits"
 msgstr "Registre des modifications"
 
-#: src/pages/features/investors.jsx:41
-#: src/pages/features/investors.jsx:76
+#: src/pages/features/investors.jsx:41 src/pages/features/investors.jsx:76
 msgid "Recurring reports"
 msgstr "Rapports récurrents"
 
-#: src/pages/pricing.jsx:14
+#: src/pages/pricing.jsx:18
 msgid "Recurring reports, KPIs"
 msgstr "Rapports récurrents, ICP"
 
@@ -983,12 +938,11 @@ msgstr "Rapports récurrents, ICP"
 msgid "Report"
 msgstr "Rapport"
 
-#: src/pages/pricing.jsx:14
+#: src/pages/pricing.jsx:18
 msgid "Reporting"
 msgstr "Rapport"
 
-#: src/components/Feature.jsx:100
-#: src/pages/features.jsx:80
+#: src/components/Feature.jsx:100 src/pages/features.jsx:80
 msgid "Round & Exit Modeling"
 msgstr "Modélisation de levée de fonds et de sorties"
 
@@ -996,8 +950,7 @@ msgstr "Modélisation de levée de fonds et de sorties"
 msgid "Round Modeling"
 msgstr "Modélisation de levée de fonds"
 
-#: src/pages/features/modeling.jsx:20
-#: src/pages/features/modeling.jsx:30
+#: src/pages/features/modeling.jsx:20 src/pages/features/modeling.jsx:30
 msgid "Round and Exit Modeling"
 msgstr "Modélisation de levée de fonds et de sorties"
 
@@ -1034,10 +987,8 @@ msgstr "Data room sécurisée"
 msgid "Secure data room, audit trail and read-only access for investors; save costly due diligence tools."
 msgstr "Data room sécurisée, piste d’audits et accès en lecture seule pour les investisseurs; économise sur les outils coûteux de diligence raisonnable."
 
-#: src/layouts/index.jsx:121
-#: src/pages/privacy.jsx:109
-#: src/pages/security.jsx:25
-#: src/pages/security.jsx:33
+#: src/layouts/index.jsx:125 src/pages/privacy.jsx:109
+#: src/pages/security.jsx:25 src/pages/security.jsx:33
 msgid "Security"
 msgstr "Sécurité"
 
@@ -1081,9 +1032,9 @@ msgstr "Partage tes scénarios au format pdf, y compris les évaluations de ton 
 msgid "Show cap table fully diluted"
 msgstr "Afficher le cap table entièrement dilué"
 
-#: src/layouts/index.jsx:81
+#: src/layouts/index.jsx:85
 msgid "Sign up"
-msgstr ""
+msgstr "S’inscrire"
 
 #: src/pages/features/modeling.jsx:120
 msgid "Simulation settings"
@@ -1097,10 +1048,8 @@ msgstr "Space elevator"
 msgid "Speed up your onboarding process with the bulk import feature"
 msgstr "Accélère l’import de tes données grâce à la fonction d’importation en masse"
 
-#: src/pages/features/captable.jsx:59
-#: src/pages/features/captable.jsx:157
-#: src/pages/features/esop.jsx:54
-#: src/pages/features/esop.jsx:152
+#: src/pages/features/captable.jsx:59 src/pages/features/captable.jsx:157
+#: src/pages/features/esop.jsx:54 src/pages/features/esop.jsx:152
 msgid "Spreadsheet importer"
 msgstr "Importateur de feuilles de calcul"
 
@@ -1128,17 +1077,13 @@ msgstr "Mots de passe forts"
 msgid "Style your reports to your needs with the rich-text editor"
 msgstr "Personnalise tes rapports selon tes besoins avec l’éditeur de texte"
 
-#: src/components/NewsletterForm.jsx:52
+#: src/components/NewsletterForm.jsx:56
 msgid "Subscribe"
-msgstr ""
+msgstr "S'abonner"
 
-#: src/layouts/index.jsx:94
+#: src/layouts/index.jsx:98
 msgid "Subscribe to the newsletter"
-msgstr ""
-
-#: src/pages/subscribed.jsx:15
-msgid "Subscription confirmed"
-msgstr ""
+msgstr "S’inscrire à la newsletter"
 
 #: src/pages/features/investors.jsx:78
 msgid "Successful companies share regular updates with their stakeholders, holding themselves accountable"
@@ -1148,8 +1093,7 @@ msgstr "Les entreprises qui réussissent partagent régulièrement des mises à 
 msgid "Suggest changes"
 msgstr "Suggérer des changements"
 
-#: src/pages/features/esop.jsx:36
-#: src/pages/features/esop.jsx:74
+#: src/pages/features/esop.jsx:36 src/pages/features/esop.jsx:74
 msgid "Supports everything"
 msgstr "Tout est pris en charge"
 
@@ -1177,7 +1121,7 @@ msgstr "Équipe"
 msgid "Technical data"
 msgstr "Données Techniques"
 
-#: src/layouts/index.jsx:217
+#: src/layouts/index.jsx:221
 msgid "Terms of Service"
 msgstr "Conditions d’utilisation"
 
@@ -1185,8 +1129,7 @@ msgstr "Conditions d’utilisation"
 msgid "The Ledgy Blog"
 msgstr "Le Blog Ledgy"
 
-#: src/layouts/index.jsx:385
-#: src/pages/index.jsx:19
+#: src/layouts/index.jsx:389 src/pages/index.jsx:19
 msgid "The New Standard in Equity Management"
 msgstr "Le nouveau standard en gestion d’actions"
 
@@ -1246,8 +1189,7 @@ msgstr "Suis de les exercices, les résiliations et les expirations"
 msgid "Track your valuations and understand the history in terms of percentage and number of shares"
 msgstr "Suis tes évaluations et comprends l’historique en termes de pourcentage et de nombre d’actions"
 
-#: src/pages/features/captable.jsx:41
-#: src/pages/features/captable.jsx:76
+#: src/pages/features/captable.jsx:41 src/pages/features/captable.jsx:76
 msgid "Transaction-based"
 msgstr "Basé sur les transactions"
 
@@ -1267,12 +1209,11 @@ msgstr "Historique transparent"
 msgid "Trust your Cap Table"
 msgstr "Fais confiance à ton cap table"
 
-#: src/pages/pricing.jsx:146
+#: src/pages/pricing.jsx:150
 msgid "Try 30 days free"
 msgstr "30 jours gratuits"
 
-#: src/pages/pricing.jsx:21
-#: src/pages/security.jsx:92
+#: src/pages/pricing.jsx:25 src/pages/security.jsx:92
 msgid "Two-factor authentication"
 msgstr "Authentification à deux facteurs"
 
@@ -1300,23 +1241,23 @@ msgstr "Comprends l’impact des préférences de liquidation"
 msgid "Unforgeable proof that your documents were not modified since the certification"
 msgstr "Preuve irréfutable que tes documents n’ont pas été modifiés depuis la certification"
 
-#: src/pages/pricing.jsx:40
+#: src/pages/pricing.jsx:44
 msgid "Unlimited"
 msgstr "Illimité"
 
-#: src/pages/pricing.jsx:39
+#: src/pages/pricing.jsx:43
 msgid "Unlimited admins"
 msgstr "Nombre illimité d’admins"
 
-#: src/pages/pricing.jsx:38
+#: src/pages/pricing.jsx:42
 msgid "Unlimited rounds & scenarios"
 msgstr "Scénarios illimités"
 
-#: src/pages/pricing.jsx:17
+#: src/pages/pricing.jsx:21
 msgid "Up to 50 MB"
 msgstr "Jusqu’à 50 MB"
 
-#: src/pages/pricing.jsx:29
+#: src/pages/pricing.jsx:33
 msgid "Up to 500 MB"
 msgstr "Jusqu’à 500 Mo"
 
@@ -1352,7 +1293,7 @@ msgstr "Numéro de TVA"
 msgid "Valuation"
 msgstr "Valeur de l’entreprise"
 
-#: src/pages/pricing.jsx:30
+#: src/pages/pricing.jsx:34
 msgid "Vesting, expiry, maturity"
 msgstr "Vesting, expiration, échéance"
 
@@ -1404,9 +1345,9 @@ msgstr "Dans la modélisation de levée de fonds, le cap table au-dessous montre
 msgid "Yoko graduated from ETH and Oxford and was president of Swissloop, enabling the team to win the 3rd price at the SpaceX Hyperloop competition"
 msgstr "Yoko est diplômée de l’ETH Zürich et d’Oxford et a été présidente de Swissloop, équipe Suisse qui a gagné le 3ème prix au concours SpaceX Hyperloop"
 
-#: src/pages/pricing.jsx:181
+#: src/pages/pricing.jsx:185
 msgid "You get a <0>20% discount</0> on Premium if your startup helps reducing carbon emissions.<1/><2>Write us</2> about your impact to see if you qualify."
-msgstr ""
+msgstr "Tu bénéficies d'un <0>rabais de 20 %</0> sur Premium si ta startup contribue à réduire les émissions de carbone.<1/><2>Écris-nous</2> au sujet de ton impact pour voir si tu es admissible."
 
 #: src/components/SecurityRow.jsx:31
 msgid "Your data is safe with us"
@@ -1424,13 +1365,13 @@ msgstr "et les actions numérotées sont soutenues nativement"
 msgid "by liquidation preferences"
 msgstr "préférences de liquidation"
 
-#: src/layouts/index.jsx:394
+#: src/layouts/index.jsx:398
 msgid "cap table, stock ledger, share register, startup, modeling, financing round, equity, esop, phantom, option plan, virtual, portfolio, reporting, investors"
 msgstr "cap table, registre d’actions, startup, modélisation, ronde de financement, levée de fonds, actions, esop, plan d’options, virtuel, portefeuille, reporting, investisseurs, plan d’options"
 
-#: src/layouts/index.jsx:98
+#: src/layouts/index.jsx:102
 msgid "for monthly updates on new features and start-up resources"
-msgstr ""
+msgstr "pour des nouvelles mensuelles sur les dernières fonctionnalités et ressources de start-up"
 
 #: src/pages/features/esop.jsx:37
 msgid "from options, to phantom and vested stock"
@@ -1448,12 +1389,11 @@ msgstr "t’aide à faire preuve de professionnalisme à l’égard de tes inves
 msgid "modeling a new round, including convertibles"
 msgstr "modélisation d’une nouvelle ronde de financement, y compris les billets convertibles"
 
-#: src/pages/pricing.jsx:147
+#: src/pages/pricing.jsx:151
 msgid "per stakeholder per month"
 msgstr "par stakeholder par mois"
 
-#: src/pages/features/captable.jsx:60
-#: src/pages/features/esop.jsx:55
+#: src/pages/features/captable.jsx:60 src/pages/features/esop.jsx:55
 msgid "save time and focus on what matters"
 msgstr "gagne du temps et concentre-toi sur ce qui compte"
 
@@ -1505,6 +1445,6 @@ msgstr "lors de la planification de ta prochaine ronde de financement"
 msgid "with a single click"
 msgstr "d’un simple clic"
 
-#: src/pages/pricing.jsx:144
+#: src/pages/pricing.jsx:148
 msgid "€2"
 msgstr "€2"

--- a/src/locale/fr/messages.po
+++ b/src/locale/fr/messages.po
@@ -14,19 +14,19 @@ msgstr ""
 "Plural-Forms: \n"
 "MIME-Version: 1.0\n"
 
-#: src/pages/pricing.jsx:56
+#: src/pages/pricing.jsx:15
 msgid "1 round, 1 scenario"
 msgstr "1 levée de fonds, 1 scénario"
 
-#: src/pages/pricing.jsx:62
+#: src/pages/pricing.jsx:16
 msgid "2 admins, stakeholder access"
 msgstr "2 admin, accès stakeholder"
 
-#: src/pages/pricing.jsx:95
-msgid "30 days trial"
-msgstr "30 jours d’essai"
+#: src/pages/pricing.jsx:83
+msgid "30-day trial"
+msgstr ""
 
-#: src/pages/pricing.jsx:127
+#: src/pages/pricing.jsx:28
 msgid "4 admins, view-only access"
 msgstr "4 admins, accès en vue seule"
 
@@ -46,19 +46,19 @@ msgstr "<0>View</0> Voir toutes les informations du cap table en mode lecture se
 msgid "A certificate of each document is automatically stored on the bitcoin blockchain when uploading"
 msgstr "Un certificat de chaque document est automatiquement stocké sur la bitcoin blockchain lors du téléchargement"
 
-#: src/pages/pricing.jsx:228
+#: src/pages/pricing.jsx:161
 msgid "A stakeholder is any holder of shares, (phantom) options, warrants, or convertibles.<0/>It does not include the company treasury or incentive pools."
 msgstr "Un stakeholder est tout détenteur d’actions, d’options (virtuelles), warrants ou de billets convertibles.<0/>Il n’inclut pas la société elle-même ni les pools d’options."
 
-#: src/layouts/index.jsx:111
+#: src/layouts/index.jsx:115
 #: src/pages/about-us.jsx:17
 #: src/pages/about-us.jsx:25
 msgid "About us"
 msgstr "À propos de nous"
 
-#: src/pages/pricing.jsx:60
-#: src/pages/pricing.jsx:125
-#: src/pages/pricing.jsx:188
+#: src/pages/pricing.jsx:16
+#: src/pages/pricing.jsx:28
+#: src/pages/pricing.jsx:39
 msgid "Access rights"
 msgstr "Droits d’accès"
 
@@ -95,17 +95,17 @@ msgstr "Ajouter un vesting à toute transaction"
 msgid "Adjust your simulations"
 msgstr "Ajuste tes simulations"
 
-#: src/pages/pricing.jsx:172
+#: src/pages/pricing.jsx:36
 msgid "All Premium features"
 msgstr "Les fonctions Premium"
-
-#: src/pages/pricing.jsx:109
-msgid "All Standard features"
-msgstr "Les fonctions Standard"
 
 #: src/pages/security.jsx:184
 msgid "All data is stored at an <0>independent provider</0> in France"
 msgstr "Toutes les données sont stockées chez un prestataire <0>indépendant </0> en France"
+
+#: src/pages/pricing.jsx:25
+msgid "All standard features"
+msgstr ""
 
 #: src/components/Feature.jsx:89
 #: src/pages/features.jsx:23
@@ -125,7 +125,7 @@ msgid "Analyze it by stakeholder, share class, stakeholder group and view it wit
 msgstr "Analyse-le par actionnaire, catégorie d’actions, groupe d’actionnaires et visualise-le avec toutes les actions en circulation ou diluées"
 
 #: src/pages/features/esop.jsx:92
-#: src/pages/pricing.jsx:115
+#: src/pages/pricing.jsx:26
 msgid "Any vesting schedule"
 msgstr "Tout calendrier de vesting"
 
@@ -203,13 +203,13 @@ msgid "Blockchain notary"
 msgstr "Notaire Blockchain"
 
 #: src/layouts/index.jsx:65
-#: src/layouts/index.jsx:114
-#: src/layouts/index.jsx:154
+#: src/layouts/index.jsx:118
+#: src/layouts/index.jsx:158
 #: src/pages/blog.jsx:61
 msgid "Blog"
 msgstr "Blog"
 
-#: src/pages/pricing.jsx:146
+#: src/pages/pricing.jsx:32
 msgid "Breakpoint & exit analyses"
 msgstr "Analyses des points d’arrêt et de sortie"
 
@@ -237,7 +237,7 @@ msgstr "Options d’entrée en bloc"
 msgid "Calculates waterfall analysis of liquidation preferences across all rounds"
 msgstr "Calcule l’analyse en cascade des préférences de liquidation à travers toutes les levées de fonds"
 
-#: src/layouts/index.jsx:185
+#: src/layouts/index.jsx:189
 msgid "Cap Table"
 msgstr "Cap Table"
 
@@ -250,11 +250,11 @@ msgstr "Gestion du cap table"
 msgid "Cap table during round modeling"
 msgstr "Cap table pendant la levée de fonds"
 
-#: src/pages/pricing.jsx:44
+#: src/pages/pricing.jsx:13
 msgid "Cap table management"
 msgstr "Gestion du cap table"
 
-#: src/layouts/index.jsx:123
+#: src/layouts/index.jsx:127
 msgid "Career"
 msgstr "Carrière"
 
@@ -272,7 +272,7 @@ msgstr "Codant depuis le lycée, Timo a obtenu un prix pour le meilleur mémoire
 msgid "Collaboration & Due Diligence"
 msgstr "Collaboration et diligence raisonnable"
 
-#: src/layouts/index.jsx:106
+#: src/layouts/index.jsx:110
 msgid "Company"
 msgstr "Société"
 
@@ -295,7 +295,7 @@ msgstr "Historique complet des transactions"
 msgid "Contact"
 msgstr "Contact"
 
-#: src/layouts/index.jsx:126
+#: src/layouts/index.jsx:130
 msgid "Contact & Imprint"
 msgstr "Contact & Mentions légales"
 
@@ -303,8 +303,8 @@ msgstr "Contact & Mentions légales"
 msgid "Contact data, usage statistics, and technical data"
 msgstr "Données de contact, statistiques d’utilisation et données techniques"
 
-#: src/pages/pricing.jsx:165
-#: src/pages/pricing.jsx:219
+#: src/pages/pricing.jsx:152
+#: src/pages/pricing.jsx:154
 msgid "Contact us"
 msgstr "Contactez-nous"
 
@@ -328,11 +328,11 @@ msgstr "Convertis le scénario final en seulement deux clics"
 msgid "Convert to transactions"
 msgstr "Convertir en transactions"
 
-#: src/pages/pricing.jsx:78
+#: src/pages/pricing.jsx:20
 msgid "Convertibles"
 msgstr "Décapotables"
 
-#: src/layouts/index.jsx:219
+#: src/layouts/index.jsx:223
 msgid "Cookie Policy"
 msgstr "Politique de Cookies"
 
@@ -369,7 +369,7 @@ msgstr "Entrepreneur et investisseur en technologies digitales. Expert en sécur
 msgid "Diluted cap table"
 msgstr "Cap table dilué"
 
-#: src/pages/pricing.jsx:236
+#: src/pages/pricing.jsx:169
 msgid "Discover all features"
 msgstr "Découvre les fonctionnalités"
 
@@ -389,17 +389,17 @@ msgstr "Liens aux documents"
 msgid "Document management"
 msgstr "Gestion des documents"
 
-#: src/pages/pricing.jsx:66
-#: src/pages/pricing.jsx:131
-#: src/pages/pricing.jsx:194
+#: src/pages/pricing.jsx:17
+#: src/pages/pricing.jsx:29
+#: src/pages/pricing.jsx:40
 msgid "Document storage"
 msgstr "Stockage des documents"
 
-#: src/pages/pricing.jsx:200
-msgid "Document workflows<0/>"
-msgstr "Workflows de documents<0/>"
+#: src/pages/pricing.jsx:43
+msgid "Document workflow <0/>"
+msgstr ""
 
-#: src/pages/pricing.jsx:242
+#: src/pages/pricing.jsx:175
 msgid "Does your startup tackle the climate crisis?"
 msgstr "Ta startup contribue-t-elle à la lutte contre le changement climatique?"
 
@@ -407,7 +407,7 @@ msgstr "Ta startup contribue-t-elle à la lutte contre le changement climatique?
 msgid "Download holding confirmations with a single click"
 msgstr "Télécharge les confirmations de possession d’un simple clic"
 
-#: src/layouts/index.jsx:194
+#: src/layouts/index.jsx:198
 msgid "Due Diligence"
 msgstr "Diligence raisonnable"
 
@@ -435,15 +435,15 @@ msgstr "Protection des données de l’UE"
 msgid "Edit log"
 msgstr "Modifier l’historique d’édition"
 
-#: src/pages/pricing.jsx:206
-msgid "Electronic signatures<0/>"
-msgstr "Signatures électroniques<0/>"
+#: src/pages/pricing.jsx:49
+msgid "Electronic signatures <0/>"
+msgstr ""
 
 #: src/pages/features/esop.jsx:123
 msgid "Email notification about upcoming vesting event"
 msgstr "Notification par e-mail d’évènement de complétion de vesting imminent"
 
-#: src/layouts/index.jsx:191
+#: src/layouts/index.jsx:195
 msgid "Employee Incentives"
 msgstr "Participation des employés"
 
@@ -466,13 +466,9 @@ msgstr "Mobilise tes employés"
 msgid "Enjoy the highest security standards"
 msgstr "Bénéficie des plus hauts standards de sécurité"
 
-#: src/components/SignupForm.jsx:43
+#: src/components/NewsletterForm.jsx:43
 msgid "Enter your email…"
 msgstr "Entre ton adresse email…"
-
-#: src/pages/pricing.jsx:161
-msgid "Enterprise"
-msgstr "Entreprise"
 
 #: src/pages/about-us.jsx:169
 msgid "Entrepreneur, business angel, founder of Doodle.com"
@@ -491,7 +487,7 @@ msgstr "Données sur les capitaux propres"
 msgid "Equity data is too important to be accidentally tweaked in a spreadsheet"
 msgstr "Les données sur les actions sont trop importantes pour être modifiées accidentellement dans une feuille de calcul"
 
-#: src/pages/pricing.jsx:113
+#: src/pages/pricing.jsx:26
 msgid "Equity plan management"
 msgstr "Plan d’actionnariat"
 
@@ -508,12 +504,12 @@ msgstr "Chaque entreprise a des indicateurs de performance clés, et les investi
 msgid "Exit modeling"
 msgstr "Modélisation de stratégie de sortie"
 
-#: src/layouts/index.jsx:142
+#: src/layouts/index.jsx:146
 msgid "FAQ"
 msgstr "FAQ"
 
 #: src/layouts/index.jsx:59
-#: src/layouts/index.jsx:182
+#: src/layouts/index.jsx:186
 #: src/pages/features/captable.jsx:21
 #: src/pages/features/collaboration.jsx:21
 #: src/pages/features/esop.jsx:16
@@ -527,15 +523,17 @@ msgstr "Fonctionalités"
 msgid "Featuring unlimited share classes, treasury shares, pooled investments, and automatic share numbering"
 msgstr "Avec un nombre illimité de catégories d’actions, d’actions autodétenues, de placements collectifs et de numérotation automatique des actions"
 
-#: src/pages/index.jsx:137
+#: src/pages/index.jsx:141
 msgid "Finally, I have a reliable overview of all our shares, employee grants, and their legal documents. So much better than the Excel I used before."
 msgstr "Enfin, j‘ai une vue d‘ensemble fiable de toutes nos actions, des attributions aux employés et de leurs documents juridiques. Tellement mieux que l‘Excel que j‘utilisais avant."
 
-#: src/pages/pricing.jsx:54 src/pages/pricing.jsx:119 src/pages/pricing.jsx:182
+#: src/pages/pricing.jsx:15
+#: src/pages/pricing.jsx:27
+#: src/pages/pricing.jsx:38
 msgid "Financing round modeling"
 msgstr "Modélisation"
 
-#: src/pages/index.jsx:151
+#: src/pages/index.jsx:155
 msgid "Find out why they trust us"
 msgstr "Découvre pourquoi ils nous font confiance"
 
@@ -551,11 +549,15 @@ msgstr "Pour une meilleure protection des comptes. Et notre implémentation est 
 msgid "Founder of Meisser Economics, Bitcoin Association Switzerland, and Wuala"
 msgstr "Fondateur de Meisser Economics, Bitcoin Association Switzerland, et Wuala"
 
-#: src/layouts/index.jsx:222
+#: src/pages/pricing.jsx:138
+msgid "Free"
+msgstr ""
+
+#: src/layouts/index.jsx:226
 msgid "GDPR"
 msgstr "RGPD"
 
-#: src/pages/index.jsx:40
+#: src/pages/index.jsx:44
 msgid "Get Started Free"
 msgstr "Commence gratuitement"
 
@@ -571,7 +573,7 @@ msgstr "Sois informé des événements importants liés au vesting et à l’exp
 msgid "Get notified two weeks before a cliff or vesting ends or a grant expires to not miss using your participation plan for engaging your employees"
 msgstr "Sois avisé deux semaines avant la fin d’une période de vesting ou de l’expiration d’options"
 
-#: src/pages/pricing.jsx:86
+#: src/pages/pricing.jsx:140
 msgid "Get started"
 msgstr "Commencer"
 
@@ -589,11 +591,11 @@ msgstr "Effectue les bons calculs"
 msgid "Get your cap table and employee participation plans right, from the beginning. Make your financing rounds a success and engage your investors and employees. Know your data is safe and compliant."
 msgstr "Bien comprendre ton cap table et tes plans d’actionnariat, dès le début. Fais de tes levées de fond un succès et mobilise tes investisseurs et tes employés. Sois sûr que tes données soient en sécurité."
 
-#: src/layouts/index.jsx:382
+#: src/layouts/index.jsx:386
 msgid "Get your cap table and employee participation plans right, from the beginning. Make your financing rounds a success and engage your investors and employees. Know your data is safe and compliant. Try now for free!"
 msgstr "Configure ton cap table et tes plans d’actionnariat des employés correctement, dès le début. Fais de tes levées de fonds un succès et mobilise tes investisseurs et tes employés. Aies la tranquillité d’esprit que tes données sont sûres et conformes. Essaye maintenant gratuitement !"
 
-#: src/layouts/index.jsx:139
+#: src/layouts/index.jsx:143
 msgid "Getting Started"
 msgstr "Commencer"
 
@@ -622,7 +624,7 @@ msgstr "Les en-têtes HTTP empêchent les scripts intersites et l’injection de
 msgid "Healthcare & technology venture capital since 2001"
 msgstr "Capital de risque dans le domaine de la santé et de la technologie depuis 2001"
 
-#: src/layouts/index.jsx:134
+#: src/layouts/index.jsx:138
 msgid "Help"
 msgstr "Aide"
 
@@ -636,7 +638,7 @@ msgstr "Confirmation de possession"
 
 #: src/pages/features/collaboration.jsx:59
 #: src/pages/features/collaboration.jsx:169
-#: src/pages/pricing.jsx:72
+#: src/pages/pricing.jsx:18
 msgid "Holding confirmations"
 msgstr "Confirmations de possession"
 
@@ -644,7 +646,7 @@ msgstr "Confirmations de possession"
 msgid "How we protect your information"
 msgstr "Comment nous protégeons tes données personnelles"
 
-#: src/pages/index.jsx:126
+#: src/pages/index.jsx:130
 msgid "I needed exactly that. Every founder should use Ledgy’s modeling tools for financing rounds!"
 msgstr "C‘est exactement ce dont j‘avais besoin. Tous les fondateurs devraient utiliser les outils de modélisation de Ledgy pour leurs levées de fonds!"
 
@@ -695,7 +697,7 @@ msgstr "Relations investisseurs et portfolio"
 msgid "Investor portfolio"
 msgstr "Portefeuille d’investisseurs"
 
-#: src/layouts/index.jsx:197
+#: src/layouts/index.jsx:201
 msgid "Investors"
 msgstr "Investisseurs"
 
@@ -707,7 +709,7 @@ msgstr "Invite le fondateur ou le directeur financier au compte de l’entrepris
 msgid "Invite your employees to track their stake and vesting in their Ledgy portfolio"
 msgstr "Invite tes employés à suivre leur part et leur vesting dans leur portefeuille Ledgy"
 
-#: src/pages/index.jsx:100
+#: src/pages/index.jsx:104
 msgid "Join hundreds of companies"
 msgstr "Rejoins des centaines d’entreprises"
 
@@ -743,7 +745,7 @@ msgstr "Indicateurs clés de performance"
 msgid "Kpi chart"
 msgstr "Diagramme Kpi"
 
-#: src/layouts/index.jsx:254
+#: src/layouts/index.jsx:258
 msgid "Language"
 msgstr "Langue"
 
@@ -767,11 +769,11 @@ msgstr "En savoir plus sur la gestion documentaire"
 msgid "Ledgy makes it easy to simulate an investment with a pro-rata distribution"
 msgstr "Ledgy facilite la simulation d’un investissement avec une distribution au prorata"
 
-#: src/pages/pricing.jsx:16
+#: src/pages/pricing.jsx:118
 msgid "Ledgy scales with your needs. Free for startups, powerful for grown-ups."
 msgstr "Ledgy s’adapte à tes besoins. Gratuit pour les startups, puissant pour les scale-ups."
 
-#: src/layouts/index.jsx:208
+#: src/layouts/index.jsx:212
 msgid "Legal"
 msgstr "Légal"
 
@@ -783,7 +785,7 @@ msgstr "Les documents juridiques associés aux transactions à portée de main"
 msgid "Let’s Get In Touch"
 msgstr "Prenons contact"
 
-#: src/pages/pricing.jsx:143
+#: src/pages/pricing.jsx:31
 msgid "Liquidation preferences"
 msgstr "Préférences de liquidation"
 
@@ -815,11 +817,11 @@ msgstr "Marius a une formation en informatique, est diplômé de l’Université
 msgid "Meet the team behind Ledgy that went out to help startups thrive. Learn more about the people who trust in us."
 msgstr "Rencontre l’équipe derrière Ledgy qui pour mission d’aider les startups à prospérer. En savoir plus sur les personnes qui nous font confiance."
 
-#: src/layouts/index.jsx:188
+#: src/layouts/index.jsx:192
 msgid "Modeling"
 msgstr "Modélisation"
 
-#: src/pages/pricing.jsx:121
+#: src/pages/pricing.jsx:27
 msgid "Multiple rounds, 3 scenarios"
 msgstr "3 scénarios"
 
@@ -831,7 +833,7 @@ msgstr "Nom, adresse email, adresse et tout autre renseignement que tu nous four
 msgid "Nobody has any access to the equity data you provide. They are safely stored at a secure data center in France. Your stakeholders have no access and don’t get emails before you explicitly invite them"
 msgstr "Personne n’a accès aux données sur les actions que tu fournis. Ils sont stockés en toute sécurité dans un centre de données sécurisé en France. Tes actionnaires n’ont pas accès et ne reçoivent pas de courriels avant que te ne les aies explicitement invités"
 
-#: src/pages/pricing.jsx:137
+#: src/pages/pricing.jsx:30
 msgid "Notifications"
 msgstr "Notifications"
 
@@ -847,7 +849,7 @@ msgstr "La cohérence des numéros est vérifiée, ce qui te donne la tranquilli
 msgid "One of the most active Swiss early-stage angel investors"
 msgstr "L’un des angel investors suisses les plus actifs en early-stage"
 
-#: src/components/SignupForm.jsx:56
+#: src/components/NewsletterForm.jsx:56
 msgid "Oops. This email address is invalid."
 msgstr "Oups. Cette adresse e-mail n’est pas valide."
 
@@ -867,7 +869,7 @@ msgstr "Cryptage du mot de passe"
 msgid "Peer-reviewed code"
 msgstr "Code révisé par l’équipe"
 
-#: src/pages/pricing.jsx:178
+#: src/pages/pricing.jsx:37
 msgid "Phone & chat, onboarding"
 msgstr "Téléphone et chat"
 
@@ -881,7 +883,7 @@ msgstr "Investissement en fond commun"
 
 #: src/pages/features/captable.jsx:47
 #: src/pages/features/captable.jsx:117
-#: src/pages/pricing.jsx:75
+#: src/pages/pricing.jsx:19
 msgid "Pooled investments"
 msgstr "Investissement en fond commun"
 
@@ -895,28 +897,24 @@ msgstr "Les placements collectifs en pool sont courants dans de nombreux pays, L
 msgid "Portfolio history"
 msgstr "Historique du portefeuille"
 
-#: src/pages/pricing.jsx:98
-msgid "Premium"
-msgstr "Premium"
-
 #: src/layouts/index.jsx:62
-#: src/layouts/index.jsx:200
-#: src/pages/pricing.jsx:15
-#: src/pages/pricing.jsx:24
+#: src/layouts/index.jsx:204
+#: src/pages/pricing.jsx:117
+#: src/pages/pricing.jsx:126
 msgid "Pricing"
 msgstr "Tarifs"
 
-#: src/pages/pricing.jsx:176
+#: src/pages/pricing.jsx:37
 msgid "Priority support"
 msgstr "Support prioritaire"
 
-#: src/layouts/index.jsx:120
+#: src/layouts/index.jsx:124
 #: src/pages/privacy.jsx:21
 #: src/pages/privacy.jsx:29
 msgid "Privacy"
 msgstr "Confidentialité"
 
-#: src/layouts/index.jsx:216
+#: src/layouts/index.jsx:220
 msgid "Privacy Policy"
 msgstr "Politique de confidentialité"
 
@@ -933,7 +931,7 @@ msgstr "Confidentialité made in Europe. Parce que tes données ne doivent pas �
 msgid "Pro-rata distribution"
 msgstr "Distribution au prorata"
 
-#: src/layouts/index.jsx:177
+#: src/layouts/index.jsx:181
 msgid "Product"
 msgstr "Produit"
 
@@ -977,7 +975,7 @@ msgstr "Registre des modifications"
 msgid "Recurring reports"
 msgstr "Rapports récurrents"
 
-#: src/pages/pricing.jsx:50
+#: src/pages/pricing.jsx:14
 msgid "Recurring reports, KPIs"
 msgstr "Rapports récurrents, ICP"
 
@@ -985,7 +983,7 @@ msgstr "Rapports récurrents, ICP"
 msgid "Report"
 msgstr "Rapport"
 
-#: src/pages/pricing.jsx:48
+#: src/pages/pricing.jsx:14
 msgid "Reporting"
 msgstr "Rapport"
 
@@ -1023,7 +1021,7 @@ msgstr "Économise sur des outils coûteux de diligence raisonnable"
 msgid "Save time in future due diligence by attaching legal documents to their transactions, making them searchable by the transaction information"
 msgstr "Gagne du temps lors de diligences raisonnables futures en joignant des documents juridiques à leurs transactions, ce qui permet d’effectuer des recherches en fonction de l’information des transactions"
 
-#: src/pages/index.jsx:45
+#: src/pages/index.jsx:49
 msgid "Screenshot of the Ledgy app"
 msgstr "Capture d’écran de l’application Ledgy"
 
@@ -1036,7 +1034,7 @@ msgstr "Data room sécurisée"
 msgid "Secure data room, audit trail and read-only access for investors; save costly due diligence tools."
 msgstr "Data room sécurisée, piste d’audits et accès en lecture seule pour les investisseurs; économise sur les outils coûteux de diligence raisonnable."
 
-#: src/layouts/index.jsx:117
+#: src/layouts/index.jsx:121
 #: src/pages/privacy.jsx:109
 #: src/pages/security.jsx:25
 #: src/pages/security.jsx:33
@@ -1083,7 +1081,7 @@ msgstr "Partage tes scénarios au format pdf, y compris les évaluations de ton 
 msgid "Show cap table fully diluted"
 msgstr "Afficher le cap table entièrement dilué"
 
-#: src/layouts/index.jsx:77
+#: src/layouts/index.jsx:81
 msgid "Sign up"
 msgstr ""
 
@@ -1130,11 +1128,11 @@ msgstr "Mots de passe forts"
 msgid "Style your reports to your needs with the rich-text editor"
 msgstr "Personnalise tes rapports selon tes besoins avec l’éditeur de texte"
 
-#: src/components/SignupForm.jsx:52
+#: src/components/NewsletterForm.jsx:52
 msgid "Subscribe"
 msgstr ""
 
-#: src/layouts/index.jsx:90
+#: src/layouts/index.jsx:94
 msgid "Subscribe to the newsletter"
 msgstr ""
 
@@ -1179,7 +1177,7 @@ msgstr "Équipe"
 msgid "Technical data"
 msgstr "Données Techniques"
 
-#: src/layouts/index.jsx:213
+#: src/layouts/index.jsx:217
 msgid "Terms of Service"
 msgstr "Conditions d’utilisation"
 
@@ -1187,7 +1185,7 @@ msgstr "Conditions d’utilisation"
 msgid "The Ledgy Blog"
 msgstr "Le Blog Ledgy"
 
-#: src/layouts/index.jsx:381
+#: src/layouts/index.jsx:385
 #: src/pages/index.jsx:19
 msgid "The New Standard in Equity Management"
 msgstr "Le nouveau standard en gestion d’actions"
@@ -1269,11 +1267,11 @@ msgstr "Historique transparent"
 msgid "Trust your Cap Table"
 msgstr "Fais confiance à ton cap table"
 
-#: src/pages/pricing.jsx:152
+#: src/pages/pricing.jsx:146
 msgid "Try 30 days free"
 msgstr "30 jours gratuits"
 
-#: src/pages/pricing.jsx:81
+#: src/pages/pricing.jsx:21
 #: src/pages/security.jsx:92
 msgid "Two-factor authentication"
 msgstr "Authentification à deux facteurs"
@@ -1302,23 +1300,23 @@ msgstr "Comprends l’impact des préférences de liquidation"
 msgid "Unforgeable proof that your documents were not modified since the certification"
 msgstr "Preuve irréfutable que tes documents n’ont pas été modifiés depuis la certification"
 
-#: src/pages/pricing.jsx:196
+#: src/pages/pricing.jsx:40
 msgid "Unlimited"
 msgstr "Illimité"
 
-#: src/pages/pricing.jsx:190
+#: src/pages/pricing.jsx:39
 msgid "Unlimited admins"
 msgstr "Nombre illimité d’admins"
 
-#: src/pages/pricing.jsx:184
+#: src/pages/pricing.jsx:38
 msgid "Unlimited rounds & scenarios"
 msgstr "Scénarios illimités"
 
-#: src/pages/pricing.jsx:68
+#: src/pages/pricing.jsx:17
 msgid "Up to 50 MB"
 msgstr "Jusqu’à 50 MB"
 
-#: src/pages/pricing.jsx:133
+#: src/pages/pricing.jsx:29
 msgid "Up to 500 MB"
 msgstr "Jusqu’à 500 Mo"
 
@@ -1354,7 +1352,7 @@ msgstr "Numéro de TVA"
 msgid "Valuation"
 msgstr "Valeur de l’entreprise"
 
-#: src/pages/pricing.jsx:139
+#: src/pages/pricing.jsx:30
 msgid "Vesting, expiry, maturity"
 msgstr "Vesting, expiration, échéance"
 
@@ -1406,9 +1404,9 @@ msgstr "Dans la modélisation de levée de fonds, le cap table au-dessous montre
 msgid "Yoko graduated from ETH and Oxford and was president of Swissloop, enabling the team to win the 3rd price at the SpaceX Hyperloop competition"
 msgstr "Yoko est diplômée de l’ETH Zürich et d’Oxford et a été présidente de Swissloop, équipe Suisse qui a gagné le 3ème prix au concours SpaceX Hyperloop"
 
-#: src/pages/pricing.jsx:248
-msgid "You get a <0>20% discount</0> on Premium, if your startup provably reduces emissions.<1/><2>Write us</2> about your impact to see if you qualify."
-msgstr "Tu bénéficies d’un <0>rabais de 20 %</0> sur Premium, si ta startup permet de réduire les émissions de manière prouvée.<1/><2>Écris-nous</2> au sujet de ton impact pour voir si tu es admissible."
+#: src/pages/pricing.jsx:181
+msgid "You get a <0>20% discount</0> on Premium if your startup helps reducing carbon emissions.<1/><2>Write us</2> about your impact to see if you qualify."
+msgstr ""
 
 #: src/components/SecurityRow.jsx:31
 msgid "Your data is safe with us"
@@ -1426,17 +1424,13 @@ msgstr "et les actions numérotées sont soutenues nativement"
 msgid "by liquidation preferences"
 msgstr "préférences de liquidation"
 
-#: src/layouts/index.jsx:390
+#: src/layouts/index.jsx:394
 msgid "cap table, stock ledger, share register, startup, modeling, financing round, equity, esop, phantom, option plan, virtual, portfolio, reporting, investors"
 msgstr "cap table, registre d’actions, startup, modélisation, ronde de financement, levée de fonds, actions, esop, plan d’options, virtuel, portefeuille, reporting, investisseurs, plan d’options"
 
-#: src/layouts/index.jsx:94
+#: src/layouts/index.jsx:98
 msgid "for monthly updates on new features and start-up resources"
 msgstr ""
-
-#: src/pages/pricing.jsx:38
-msgid "free"
-msgstr "gratuit"
 
 #: src/pages/features/esop.jsx:37
 msgid "from options, to phantom and vested stock"
@@ -1454,7 +1448,7 @@ msgstr "t’aide à faire preuve de professionnalisme à l’égard de tes inves
 msgid "modeling a new round, including convertibles"
 msgstr "modélisation d’une nouvelle ronde de financement, y compris les billets convertibles"
 
-#: src/pages/pricing.jsx:104
+#: src/pages/pricing.jsx:147
 msgid "per stakeholder per month"
 msgstr "par stakeholder par mois"
 
@@ -1479,7 +1473,7 @@ msgstr "pour que tu puisse contrôler ce que les autres peuvent voir et faire"
 msgid "stopping the spreadsheet mess"
 msgstr "l’arrêt du désordre des feuilles de calcul"
 
-#: src/pages/index.jsx:103
+#: src/pages/index.jsx:107
 msgid "that already use Ledgy for their equity management and investor relations"
 msgstr "qui utilisent déjà Ledgy pour la gestion de leurs actions et leurs relations avec les investisseurs"
 
@@ -1511,6 +1505,6 @@ msgstr "lors de la planification de ta prochaine ronde de financement"
 msgid "with a single click"
 msgstr "d’un simple clic"
 
-#: src/pages/pricing.jsx:101
+#: src/pages/pricing.jsx:144
 msgid "€2"
 msgstr "€2"

--- a/src/pages/features.jsx
+++ b/src/pages/features.jsx
@@ -149,7 +149,7 @@ export default withI18n()(({ i18n, ...props }: Props) => (
 
           <Hr />
 
-          <SecurityRow {...props} />
+          <SecurityRow {...props} i18n={i18n} />
         </div>
       </section>
 

--- a/src/pages/index.jsx
+++ b/src/pages/index.jsx
@@ -63,7 +63,7 @@ const Testimonial = ({
 }: {
   img: Object,
   name: string,
-  description: React.Element,
+  description: React.Node,
   col: number
 }) => (
   <div

--- a/src/pages/index.jsx
+++ b/src/pages/index.jsx
@@ -7,7 +7,7 @@ import Img from 'gatsby-image';
 
 import { FeatureLinks } from '../components/Feature';
 import SecurityRow from '../components/SecurityRow';
-import { demoUrl, targetBlank, Hr } from '../layouts/utils';
+import { demoUrl, targetBlank, Hr, appUrl, trackSignup } from '../layouts/utils';
 
 const Header = ({ i18n, data }: Props) => {
   return (
@@ -36,7 +36,11 @@ const Header = ({ i18n, data }: Props) => {
             >
               <Trans>See the Demo</Trans>
             </a>
-            <a className="btn btn-block d-sm-inline btn-xl mx-1 btn-round btn-light" href="#try">
+            <a
+              className="btn btn-block d-sm-inline btn-xl mx-1 btn-round btn-light"
+              href={`${appUrl}/signup`}
+              onClick={trackSignup}
+            >
               <Trans>Get Started Free</Trans>
             </a>
           </div>

--- a/src/pages/pricing.jsx
+++ b/src/pages/pricing.jsx
@@ -7,7 +7,11 @@ import { Link } from 'gatsby';
 import { Title, Li, ChevronRight, appUrl, trackSignup } from '../layouts/utils';
 
 const Detail = props => <small className="d-block text-light mt-1" {...props} />;
-const Soon = () => <small className="badge badge-pill badge-primary fs-10 ml-1">Coming soon</small>;
+const Soon = () => (
+  <small className="badge badge-pill badge-primary fs-10 ml-1">
+    <Trans>Coming soon</Trans>
+  </small>
+);
 
 const standard = [
   [1, <Trans>Cap table management</Trans>, '', true],

--- a/src/pages/pricing.jsx
+++ b/src/pages/pricing.jsx
@@ -75,7 +75,7 @@ const PricingColumn = (props: {
   <div className="col-lg-4">
     <div
       className={`pricing-3 border rounded pb-4 ${
-        props.popular ? 'popular, border, border-success, shadow' : ''
+        props.popular ? 'popular border border-success shadow' : ''
       }`}
     >
       {props.popular && (

--- a/src/pages/pricing.jsx
+++ b/src/pages/pricing.jsx
@@ -4,7 +4,7 @@ import * as React from 'react';
 import { withI18n, Trans } from '@lingui/react';
 import { Link } from 'gatsby';
 
-import { Title, Li, ChevronRight } from '../layouts/utils';
+import { Title, Li, ChevronRight, appUrl, trackSignup } from '../layouts/utils';
 
 const Detail = props => <small className="d-block text-light mt-1" {...props} />;
 const Soon = () => <small className="badge badge-pill badge-primary fs-10">Coming soon</small>;
@@ -148,7 +148,11 @@ export default withI18n()(({ i18n, ...props }: Props) => (
                   <li>&nbsp;</li>
                 </ul>
                 <div className="text-center mb-3">
-                  <a href="#try" className="btn btn-round btn-xl btn-primary">
+                  <a
+                    href={`${appUrl}/signup`}
+                    onClick={trackSignup}
+                    className="btn btn-round btn-xl btn-primary"
+                  >
                     <Trans>Try 30 days free</Trans>
                   </a>
                 </div>

--- a/src/pages/pricing.jsx
+++ b/src/pages/pricing.jsx
@@ -78,7 +78,7 @@ const PricingColumn = (props: {
 }) => (
   <div className="col-lg-4">
     <div
-      className={`pricing-3 border rounded pb-4 ${
+      className={`pricing-3 border rounded pb-4 mx-auto ${
         props.popular ? 'popular border border-success shadow' : ''
       }`}
     >

--- a/src/pages/pricing.jsx
+++ b/src/pages/pricing.jsx
@@ -82,7 +82,11 @@ export default withI18n()(({ i18n, ...props }: Props) => (
                   </Li>
                 </ul>
                 <div className="text-center mb-3">
-                  <a href="#try" className="btn btn-round btn-xl btn-outline-primary">
+                  <a
+                    href={`${appUrl}/signup`}
+                    onClick={trackSignup}
+                    className="btn btn-round btn-xl btn-outline-primary"
+                  >
                     <Trans>Get started</Trans>
                   </a>
                 </div>

--- a/src/pages/pricing.jsx
+++ b/src/pages/pricing.jsx
@@ -7,7 +7,107 @@ import { Link } from 'gatsby';
 import { Title, Li, ChevronRight, appUrl, trackSignup } from '../layouts/utils';
 
 const Detail = props => <small className="d-block text-light mt-1" {...props} />;
-const Soon = () => <small className="badge badge-pill badge-primary fs-10">Coming soon</small>;
+const Soon = () => <small className="badge badge-pill badge-primary fs-10 ml-1">Coming soon</small>;
+
+const standard = [
+  [1, <Trans>Cap table management</Trans>, '', true],
+  [2, <Trans>Reporting</Trans>, <Trans>Recurring reports, KPIs</Trans>],
+  [3, <Trans>Financing round modeling</Trans>, <Trans>1 round, 1 scenario</Trans>],
+  [4, <Trans>Access rights</Trans>, <Trans>2 admins, stakeholder access</Trans>],
+  [5, <Trans>Document storage</Trans>, <Trans>Up to 50 MB</Trans>],
+  [6, <Trans>Holding confirmations</Trans>],
+  [7, <Trans>Pooled investments</Trans>],
+  [8, <Trans>Convertibles</Trans>],
+  [9, <Trans>Two-factor authentication</Trans>]
+];
+
+const premium = [
+  [10, <Trans>All standard features</Trans>, '', true],
+  [11, <Trans>Equity plan management</Trans>, <Trans>Any vesting schedule</Trans>],
+  [12, <Trans>Financing round modeling</Trans>, <Trans>Multiple rounds, 3 scenarios</Trans>],
+  [13, <Trans>Access rights</Trans>, <Trans>4 admins, view-only access</Trans>],
+  [14, <Trans>Document storage</Trans>, <Trans>Up to 500 MB</Trans>],
+  [15, <Trans>Notifications</Trans>, <Trans>Vesting, expiry, maturity</Trans>],
+  [16, <Trans>Liquidation preferences</Trans>],
+  [17, <Trans>Breakpoint & exit analyses</Trans>]
+];
+
+const enterprise = [
+  [18, <Trans>All Premium features</Trans>, '', true],
+  [19, <Trans>Priority support</Trans>, <Trans>Phone & chat, onboarding</Trans>],
+  [20, <Trans>Financing round modeling</Trans>, <Trans>Unlimited rounds & scenarios</Trans>],
+  [21, <Trans>Access rights</Trans>, <Trans>Unlimited admins</Trans>],
+  [22, <Trans>Document storage</Trans>, <Trans>Unlimited</Trans>],
+  [
+    23,
+    <Trans>
+      Document workflow <Soon />
+    </Trans>
+  ],
+  [
+    24,
+    <Trans>
+      Electronic signatures <Soon />
+    </Trans>
+  ]
+];
+
+const PlanFeatures = ({ features }: { features: Array<React.Element | boolean> }) => (
+  <ul>
+    {features.map(([i, description, detail, first]) => (
+      <Li key={i}>
+        {first ? <strong>{description}</strong> : description}
+        {detail && <Detail>{detail}</Detail>}
+      </Li>
+    ))}
+  </ul>
+);
+
+const PricingColumn = (props: {
+  name: string,
+  price: React.Element,
+  plan: Array<React.Element | boolean>,
+  buttonText: React.Element,
+  popular?: boolean,
+  detail?: React.Element,
+  enterprise?: boolean
+}) => (
+  <div className="col-lg-6 col-xl-4">
+    <div
+      className={`pricing-3 border rounded pb-4 ${
+        props.popular ? 'popular, border, border-success, shadow' : ''
+      }`}
+    >
+      {props.popular && (
+        <span className="popular-tag">
+          <Trans>30-day trial</Trans>
+        </span>
+      )}
+      <div className="d-flex flex-column justify-content-between h-100">
+        <div>
+          <h3>{props.name}</h3>
+          <h5>{props.price}</h5>
+          <Detail>{props.detail ? props.detail : <>&nbsp;</>}</Detail>
+          <ul className="text-left mt-6 mb-0">
+            <PlanFeatures features={props.plan} />
+          </ul>
+        </div>
+        <div className="text-center mb-3">
+          <a
+            href={props.enterprise ? 'mailto:sales@ledgy.com' : `${appUrl}/signup`}
+            onClick={props.enterprise ? () => null : trackSignup}
+            className={`btn btn-round btn-xl ${
+              props.popular ? 'btn-primary' : 'btn-outline-primary'
+            }`}
+          >
+            {props.buttonText}
+          </a>
+        </div>
+      </div>
+    </div>
+  </div>
+);
+PricingColumn.defaultProps = { popular: false, detail: '', enterprise: false };
 
 export default withI18n()(({ i18n, ...props }: Props) => (
   <div>
@@ -31,204 +131,27 @@ export default withI18n()(({ i18n, ...props }: Props) => (
       <section className="section">
         <div className="container">
           <div className="justify-content-center row gap-y">
-            <div className="col-lg-4">
-              <div className="pricing-3 border rounded pb-4">
-                <h3>Standard</h3>
-                <h5>
-                  <Trans>free</Trans>
-                </h5>
-                <Detail>&nbsp;</Detail>
-                <ul className="text-left mt-6 mb-0">
-                  <Li>
-                    <strong>
-                      <Trans>Cap table management</Trans>
-                    </strong>
-                  </Li>
-                  <Li>
-                    <Trans>Reporting</Trans>
-                    <Detail>
-                      <Trans>Recurring reports, KPIs</Trans>
-                    </Detail>
-                  </Li>
-                  <Li>
-                    <Trans>Financing round modeling</Trans>
-                    <Detail>
-                      <Trans>1 round, 1 scenario</Trans>
-                    </Detail>
-                  </Li>
-                  <Li>
-                    <Trans>Access rights</Trans>
-                    <Detail>
-                      <Trans>2 admins, stakeholder access</Trans>
-                    </Detail>
-                  </Li>
-                  <Li>
-                    <Trans>Document storage</Trans>
-                    <Detail>
-                      <Trans>Up to 50 MB</Trans>
-                    </Detail>
-                  </Li>
-                  <Li>
-                    <Trans>Holding confirmations</Trans>
-                  </Li>
-                  <Li>
-                    <Trans>Pooled investments</Trans>
-                  </Li>
-                  <Li>
-                    <Trans>Convertibles</Trans>
-                  </Li>
-                  <Li>
-                    <Trans>Two-factor authentication</Trans>
-                  </Li>
-                </ul>
-                <div className="text-center mb-3">
-                  <a
-                    href={`${appUrl}/signup`}
-                    onClick={trackSignup}
-                    className="btn btn-round btn-xl btn-outline-primary"
-                  >
-                    <Trans>Get started</Trans>
-                  </a>
-                </div>
-              </div>
-            </div>
-
-            <div className="col-lg-4">
-              <div className="pricing-3 popular border border-success rounded pb-4 shadow">
-                <span className="popular-tag">
-                  <Trans>30 days trial</Trans>
-                </span>
-                <h3>
-                  <Trans>Premium</Trans>
-                </h3>
-                <h5>
-                  <Trans>€2</Trans>
-                </h5>
-                <Detail>
-                  <Trans>per stakeholder per month</Trans>
-                </Detail>
-                <ul className="text-left mt-6 mb-0">
-                  <Li>
-                    <strong>
-                      <Trans>All Standard features</Trans>
-                    </strong>
-                  </Li>
-                  <Li>
-                    <Trans>Equity plan management</Trans>
-                    <Detail>
-                      <Trans>Any vesting schedule</Trans>
-                    </Detail>
-                  </Li>
-                  <Li>
-                    <Trans>Financing round modeling</Trans>
-                    <Detail>
-                      <Trans>Multiple rounds, 3 scenarios</Trans>
-                    </Detail>
-                  </Li>
-                  <Li>
-                    <Trans>Access rights</Trans>
-                    <Detail>
-                      <Trans>4 admins, view-only access</Trans>
-                    </Detail>
-                  </Li>
-                  <Li>
-                    <Trans>Document storage</Trans>
-                    <Detail>
-                      <Trans>Up to 500 MB</Trans>
-                    </Detail>
-                  </Li>
-                  <Li>
-                    <Trans>Notifications</Trans>
-                    <Detail>
-                      <Trans>Vesting, expiry, maturity</Trans>
-                    </Detail>
-                  </Li>
-                  <Li>
-                    <Trans>Liquidation preferences</Trans>
-                  </Li>
-                  <Li>
-                    <Trans>Breakpoint & exit analyses</Trans>
-                  </Li>
-                  <li>&nbsp;</li>
-                </ul>
-                <div className="text-center mb-3">
-                  <a
-                    href={`${appUrl}/signup`}
-                    onClick={trackSignup}
-                    className="btn btn-round btn-xl btn-primary"
-                  >
-                    <Trans>Try 30 days free</Trans>
-                  </a>
-                </div>
-              </div>
-            </div>
-
-            <div className="col-lg-4">
-              <div className="pricing-3 border rounded pb-4">
-                <h3>
-                  <Trans>Enterprise</Trans>
-                </h3>
-                <h5>
-                  <a href="mailto:sales@ledgy.com">
-                    <Trans>Contact us</Trans>
-                  </a>
-                </h5>
-                <Detail>&nbsp;</Detail>
-                <ul className="text-left mt-6 mb-0">
-                  <Li>
-                    <strong>
-                      <Trans>All Premium features</Trans>
-                    </strong>
-                  </Li>
-                  <Li>
-                    <Trans>Priority support</Trans>
-                    <Detail>
-                      <Trans>Phone & chat, onboarding</Trans>
-                    </Detail>
-                  </Li>
-                  <Li>
-                    <Trans>Financing round modeling</Trans>
-                    <Detail>
-                      <Trans>Unlimited rounds & scenarios</Trans>
-                    </Detail>
-                  </Li>
-                  <Li>
-                    <Trans>Access rights</Trans>
-                    <Detail>
-                      <Trans>Unlimited admins</Trans>
-                    </Detail>
-                  </Li>
-                  <Li>
-                    <Trans>Document storage</Trans>
-                    <Detail>
-                      <Trans>Unlimited</Trans>
-                    </Detail>
-                  </Li>
-                  <Li>
-                    <Trans>
-                      Document workflows
-                      <Soon />
-                    </Trans>
-                  </Li>
-                  <Li>
-                    <Trans>
-                      Electronic signatures
-                      <Soon />
-                    </Trans>
-                  </Li>
-                  <li>&nbsp;</li>
-                  <li>&nbsp;</li>
-                </ul>
-                <div className="text-center mb-3">
-                  <a
-                    href="mailto:sales@ledgy.com"
-                    className="btn btn-round btn-xl btn-outline-primary"
-                  >
-                    <Trans>Contact us</Trans>
-                  </a>
-                </div>
-              </div>
-            </div>
+            <PricingColumn
+              name="Standard"
+              price={<Trans>Free</Trans>}
+              plan={standard}
+              buttonText={<Trans>Get started</Trans>}
+            />
+            <PricingColumn
+              name="Premium"
+              price={<Trans>€2</Trans>}
+              plan={premium}
+              buttonText={<Trans>Try 30 days free</Trans>}
+              detail={<Trans>per stakeholder per month</Trans>}
+              popular
+            />
+            <PricingColumn
+              name="Enterprise"
+              price={<Trans>Contact us</Trans>}
+              plan={enterprise}
+              buttonText={<Trans>Contact us</Trans>}
+              enterprise
+            />
           </div>
 
           <div className="text-center mt-6">
@@ -254,8 +177,8 @@ export default withI18n()(({ i18n, ...props }: Props) => (
             </h5>
             <p>
               <Trans>
-                You get a <strong>20% discount</strong> on Premium, if your startup provably reduces
-                emissions.
+                You get a <strong>20% discount</strong> on Premium if your startup helps reducing
+                carbon emissions.
                 <br />
                 <a href="mailto:contact@ledgy.com?subject=Premium Eco-Friendly Discount Application">
                   Write us

--- a/src/pages/pricing.jsx
+++ b/src/pages/pricing.jsx
@@ -72,7 +72,7 @@ const PricingColumn = (props: {
   detail?: React.Element,
   enterprise?: boolean
 }) => (
-  <div className="col-lg-6 col-xl-4">
+  <div className="col-lg-4">
     <div
       className={`pricing-3 border rounded pb-4 ${
         props.popular ? 'popular, border, border-success, shadow' : ''
@@ -85,9 +85,11 @@ const PricingColumn = (props: {
       )}
       <div className="d-flex flex-column justify-content-between h-100">
         <div>
-          <h3>{props.name}</h3>
-          <h5>{props.price}</h5>
-          <Detail>{props.detail ? props.detail : <>&nbsp;</>}</Detail>
+          <div className="pricing-top">
+            <h3>{props.name}</h3>
+            <h5>{props.price}</h5>
+            <Detail>{props.detail ? props.detail : <>&nbsp;</>}</Detail>
+          </div>
           <ul className="text-left mt-6 mb-0">
             <PlanFeatures features={props.plan} />
           </ul>

--- a/src/pages/pricing.jsx
+++ b/src/pages/pricing.jsx
@@ -56,7 +56,7 @@ const enterprise = [
   ]
 ];
 
-const PlanFeatures = ({ features }: { features: Array<React.Element | boolean> }) => (
+const PlanFeatures = ({ features }: { features: Array<React.Node | boolean> }) => (
   <ul>
     {features.map(([i, description, detail, first]) => (
       <Li key={i}>
@@ -69,11 +69,11 @@ const PlanFeatures = ({ features }: { features: Array<React.Element | boolean> }
 
 const PricingColumn = (props: {
   name: string,
-  price: React.Element,
-  plan: Array<React.Element | boolean>,
-  buttonText: React.Element,
+  price: React.Node,
+  plan: Array<React.Node | boolean>,
+  buttonText: React.Node,
   popular?: boolean,
-  detail?: React.Element,
+  detail?: React.Node,
   enterprise?: boolean
 }) => (
   <div className="col-lg-4">

--- a/src/pages/subscribed.jsx
+++ b/src/pages/subscribed.jsx
@@ -5,7 +5,7 @@ import { Link } from 'gatsby';
 import { Trans } from '@lingui/react';
 import { appUrl } from '../layouts/utils';
 
-export default () => (
+export default (props: LayoutProps) => (
   <>
     <header className="header text-white bg-ledgy">
       <div className="container text-center">
@@ -24,24 +24,20 @@ export default () => (
           <div className="bg-gray h-full p-5 imprint">
             <div className="row justify-content-center">
               <div className="d-flex flex-column align-items-center text-center w-md-75">
-                <p>Your subscription to our newsletter is now active.</p>
-                <p>
-                  You will receive approximately one email per month. If you want to cancel your
-                  subscription, you will be able to do so on the newsletter emails.
-                </p>
                 <p>
                   Thank you for your interest in Ledgy{' '}
                   <span role="img" aria-label="rocket">
                     🚀
                   </span>
                 </p>
+                <p>You can cancel your subscription through any of our newsletter emails.</p>
                 <div className="d-flex flex-column flex-md-row mt-2">
                   <Link
                     className="btn btn-round btn-outline-primary btn-xl mr-md-1 mb-3 mb-md-0"
                     href
-                    to="/"
+                    to={`${props.prefix}/features`}
                   >
-                    <Trans>Continue to site</Trans>
+                    <Trans>Continue exploring</Trans>
                   </Link>
                   <a className="btn btn-round btn-primary btn-xl ml-md-1" href={appUrl}>
                     <Trans>Go to Ledgy app</Trans>

--- a/src/pages/subscribed.jsx
+++ b/src/pages/subscribed.jsx
@@ -11,9 +11,7 @@ export default (props: LayoutProps) => (
       <div className="container text-center">
         <div className="row">
           <div className="col-12 col-lg-8 offset-lg-2">
-            <h1>
-              <Trans>Subscription confirmed</Trans>
-            </h1>
+            <h1>Subscription confirmed</h1>
           </div>
         </div>
       </div>
@@ -37,11 +35,8 @@ export default (props: LayoutProps) => (
                     href
                     to={`${props.prefix}/features`}
                   >
-                    <Trans>Continue exploring</Trans>
+                    Continue exploring
                   </Link>
-                  <a className="btn btn-round btn-primary btn-xl ml-md-1" href={appUrl}>
-                    <Trans>Go to Ledgy app</Trans>
-                  </a>
                 </div>
               </div>
             </div>

--- a/src/pages/subscribed.jsx
+++ b/src/pages/subscribed.jsx
@@ -2,8 +2,6 @@
 
 import React from 'react';
 import { Link } from 'gatsby';
-import { Trans } from '@lingui/react';
-import { appUrl } from '../layouts/utils';
 
 export default (props: LayoutProps) => (
   <>

--- a/src/pages/subscribed.jsx
+++ b/src/pages/subscribed.jsx
@@ -1,0 +1,57 @@
+// @flow
+
+import React from 'react';
+import { Link } from 'gatsby';
+import { Trans } from '@lingui/react';
+import { appUrl } from '../layouts/utils';
+
+export default () => (
+  <>
+    <header className="header text-white bg-ledgy">
+      <div className="container text-center">
+        <div className="row">
+          <div className="col-12 col-lg-8 offset-lg-2">
+            <h1>
+              <Trans>Subscription confirmed</Trans>
+            </h1>
+          </div>
+        </div>
+      </div>
+    </header>
+    <main className="main-content">
+      <div className="section">
+        <div className="container">
+          <div className="bg-gray h-full p-5 imprint">
+            <div className="row justify-content-center">
+              <div className="d-flex flex-column align-items-center text-center w-md-75">
+                <p>Your subscription to our newsletter is now active.</p>
+                <p>
+                  You will receive approximately one email per month. If you want to cancel your
+                  subscription, you will be able to do so on the newsletter emails.
+                </p>
+                <p>
+                  Thank you for your interest in Ledgy{' '}
+                  <span role="img" aria-label="rocket">
+                    🚀
+                  </span>
+                </p>
+                <div className="d-flex flex-column flex-md-row mt-2">
+                  <Link
+                    className="btn btn-round btn-outline-primary btn-xl mr-md-1 mb-3 mb-md-0"
+                    href
+                    to="/"
+                  >
+                    <Trans>Continue to site</Trans>
+                  </Link>
+                  <a className="btn btn-round btn-primary btn-xl ml-md-1" href={appUrl}>
+                    <Trans>Go to Ledgy app</Trans>
+                  </a>
+                </div>
+              </div>
+            </div>
+          </div>
+        </div>
+      </div>
+    </main>
+  </>
+);


### PR DESCRIPTION
TODOs

- [x]  On mailchimp, go to Audience --> Signup forms --> Form builder --> Confirmation thank you page (on forms and response emails drodpdown) and set URL to `https://www.ledgy.com/subscribed/`
- [x]  On that same dropdown, go to 'Signup from with alerts' and customize it so it only includes the email (+ further customization if you want). The user will be redirected to this ugly form if he/she enters an already stored email

- [x]  Translate to German
- [x]  Translate to French
- [x] Double-check subscriptions work (tested with my mailchimp account)