### PR TITLE
add redirect for netlify

### DIFF
--- a/static/_redirects
+++ b/static/_redirects
@@ -1,0 +1,1 @@
+https://ledgy.netlify.com/* https://www.ledgy.com/:splat 301!


### PR DESCRIPTION
Adds a redirect from [netlify.ledgy.com](https://netlify.ledgy.com) to www.ledgy.com so that Google doesn’t see duplicate content on different locations. (Can harm SEO apparently)