### PR TITLE
redirect to localized version immediately

### DIFF
--- a/gatsby-browser.js
+++ b/gatsby-browser.js
@@ -8,7 +8,7 @@ exports.onServiceWorkerUpdateReady = () => window.location.reload(true);
 
 if (window.ga) {
   window.ga('require', 'linker');
-  window.ga('linker:autoLink', ['app.ledgy.com']);
+  window.ga('linker:autoLink', ['app.ledgy.com', 'demo.ledgy.com']);
   window.ga(tracker => {
     window.clientId = tracker.get('clientId');
   });

--- a/src/components/FAQ.jsx
+++ b/src/components/FAQ.jsx
@@ -1,6 +1,7 @@
 // @flow
 
 import React, { type Node } from 'react';
+import { isBrowser } from '../layouts/utils';
 
 export const Accordion = (props: { children: Node }) => (
   <div className="accordion my-4" {...props} />
@@ -15,7 +16,7 @@ export const FAQ = ({
   question: string,
   children: Node
 |}) => {
-  const isOpen = typeof window !== 'undefined' && window.top.location.hash === `#${id}`;
+  const isOpen = isBrowser && window.top.location.hash === `#${id}`;
   return (
     <div className="card mb-0">
       <h6 className="card-title mt-0 bg-white" id={id}>

--- a/src/layouts/index.jsx
+++ b/src/layouts/index.jsx
@@ -1,7 +1,7 @@
 // @flow
 
 import React, { useEffect, type Node } from 'react';
-import { StaticQuery, graphql, Link, navigate } from 'gatsby';
+import { StaticQuery, graphql, Link } from 'gatsby';
 import { I18nProvider, withI18n, Trans } from '@lingui/react';
 import { Helmet } from 'react-helmet';
 import { FontAwesomeIcon } from '@fortawesome/react-fontawesome';
@@ -17,17 +17,8 @@ import 'typeface-work-sans'; // eslint-disable-line import/extensions
 import 'katex/dist/katex.min.css';
 import 'prism-themes/themes/prism-ghcolors.css';
 
-import {
-  Title,
-  name,
-  appUrl,
-  loadScript,
-  targetBlank,
-  animateTablet,
-  trackSignup,
-  isBrowser
-} from './utils';
-import { catalogs, langFromPath, langPrefix, getLocale, deprefix } from '../i18n-config';
+import { Title, name, appUrl, loadScript, targetBlank, animateTablet, trackSignup } from './utils';
+import { catalogs, langFromPath, langPrefix, deprefix } from '../i18n-config';
 import NewsletterForm from '../components/NewsletterForm';
 
 import '../assets/scss/page.scss';
@@ -414,12 +405,7 @@ const TemplateWrapper = withI18n()(({ children, ...props }: SiteProps) => (
 ));
 
 export default (props: {| location: {| pathname: string |} |}) => {
-  const { pathname } = props.location;
-  const lang = langFromPath(pathname);
-
-  if (isBrowser && getLocale() === 'de' && !pathname.startsWith('/de')) {
-    navigate(`/de${pathname}`);
-  }
+  const lang = langFromPath(props.location.pathname);
   return (
     <I18nProvider language={lang} catalogs={catalogs}>
       <TemplateWrapper {...props} lang={lang} />

--- a/src/layouts/index.jsx
+++ b/src/layouts/index.jsx
@@ -285,16 +285,12 @@ type SiteProps = {
   location: { pathname: string }
 };
 
-const Initialize = ({ pathname }: {| pathname: string |}) => {
+const Initialize = () => {
   useEffect(() => {
     animateTablet();
     setTimeout(async () => {
       require('../assets/js/page'); // eslint-disable-line global-require
       require('../assets/js/script'); // eslint-disable-line global-require
-
-      if (getLocale() === 'de' && !pathname.startsWith('/de')) {
-        navigate(`/de${pathname}`);
-      }
 
       await loadScript('https://wchat.eu.freshchat.com/js/widget.js');
       window.fcSettings = {
@@ -362,7 +358,7 @@ const TemplateWrapper = withI18n()(({ children, ...props }: SiteProps) => (
             description={i18n.t`Get your cap table and employee participation plans right, from the beginning. Make your financing rounds a success and engage your investors and employees. Know your data is safe and compliant. Try now for free!`}
             thumbnailUrl={thumbnailUrl}
           />
-          <Initialize pathname={pathname} />
+          <Initialize />
           <Helmet>
             <html lang={lang} />
             <meta
@@ -409,7 +405,13 @@ const TemplateWrapper = withI18n()(({ children, ...props }: SiteProps) => (
 ));
 
 export default (props: {| location: {| pathname: string |} |}) => {
-  const lang = langFromPath(props.location.pathname);
+  const { pathname } = props.location;
+  const lang = langFromPath(pathname);
+
+  if (getLocale() === 'de' && !pathname.startsWith('/de')) {
+    navigate(`/de${pathname}`);
+    return null;
+  }
   return (
     <I18nProvider language={lang} catalogs={catalogs}>
       <TemplateWrapper {...props} lang={lang} />

--- a/src/layouts/index.jsx
+++ b/src/layouts/index.jsx
@@ -419,7 +419,6 @@ export default (props: {| location: {| pathname: string |} |}) => {
 
   if (isBrowser && getLocale() === 'de' && !pathname.startsWith('/de')) {
     navigate(`/de${pathname}`);
-    return null;
   }
   return (
     <I18nProvider language={lang} catalogs={catalogs}>

--- a/src/layouts/index.jsx
+++ b/src/layouts/index.jsx
@@ -349,8 +349,7 @@ const TemplateWrapper = withI18n()(({ children, ...props }: SiteProps) => (
       const prefix = langPrefix(lang);
       const { siteUrl } = data.site.siteMetadata;
       const thumbnailUrl = `${siteUrl}/thumbnail.png`;
-      const { pathname } = props.location;
-      const EnPathname = `${siteUrl}${pathname.startsWith('/de') ? pathname.substr(3) : pathname}`;
+      const pathname = deprefix(props.location.pathname);
       return (
         <div>
           <Title
@@ -375,13 +374,10 @@ const TemplateWrapper = withI18n()(({ children, ...props }: SiteProps) => (
             <meta name="twitter:site" content="@Ledgy" />
             <meta name="twitter:card" content="summary_large_image" />
 
-            <link rel="alternate" href={EnPathname} hrefLang="x-default" />
-            <link rel="alternate" href={EnPathname} hrefLang="en" />
-            <link
-              rel="alternate"
-              href={`${siteUrl}${pathname.startsWith('/de') ? '' : '/de'}${pathname}`}
-              hrefLang="de"
-            />
+            <link rel="alternate" href={`${siteUrl}${pathname}`} hrefLang="x-default" />
+            <link rel="alternate" href={`${siteUrl}${pathname}`} hrefLang="en" />
+            <link rel="alternate" href={`${siteUrl}/de${pathname}`} hrefLang="de" />
+            <link rel="alternate" href={`${siteUrl}/fr${pathname}`} hrefLang="fr" />
 
             {/* Disable AOS for Google */}
             <noscript>

--- a/src/layouts/index.jsx
+++ b/src/layouts/index.jsx
@@ -17,7 +17,16 @@ import 'typeface-work-sans'; // eslint-disable-line import/extensions
 import 'katex/dist/katex.min.css';
 import 'prism-themes/themes/prism-ghcolors.css';
 
-import { Title, name, appUrl, loadScript, targetBlank, animateTablet, trackSignup } from './utils';
+import {
+  Title,
+  name,
+  appUrl,
+  loadScript,
+  targetBlank,
+  animateTablet,
+  trackSignup,
+  isBrowser
+} from './utils';
 import { catalogs, langFromPath, langPrefix, getLocale, deprefix } from '../i18n-config';
 import NewsletterForm from '../components/NewsletterForm';
 
@@ -408,7 +417,7 @@ export default (props: {| location: {| pathname: string |} |}) => {
   const { pathname } = props.location;
   const lang = langFromPath(pathname);
 
-  if (getLocale() === 'de' && !pathname.startsWith('/de')) {
+  if (isBrowser && getLocale() === 'de' && !pathname.startsWith('/de')) {
     navigate(`/de${pathname}`);
     return null;
   }

--- a/src/layouts/utils.jsx
+++ b/src/layouts/utils.jsx
@@ -17,6 +17,8 @@ export const wirtschaftswocheUrl =
 
 export const targetBlank = { target: '_blank', rel: 'noopener noreferrer' };
 
+export const isBrowser = typeof window !== 'undefined';
+
 export const loadScript = (path: string): Promise<*> =>
   new Promise((resolve, reject) => {
     const script = document.createElement('script');

--- a/src/pages/index.jsx
+++ b/src/pages/index.jsx
@@ -16,7 +16,8 @@ import {
   trackSignup,
   forbesUrl,
   economistUrl,
-  wirtschaftswocheUrl
+  wirtschaftswocheUrl,
+  isBrowser
 } from '../layouts/utils';
 
 const experiments = [
@@ -46,7 +47,7 @@ const experiments = [
   }
 ];
 
-const experiment = typeof window !== 'undefined' ? sample(experiments) : experiments[0];
+const experiment = isBrowser ? sample(experiments) : experiments[0];
 
 const Header = ({ i18n, data }: Props) => {
   useEffect(() => {

--- a/static/_redirects
+++ b/static/_redirects
@@ -1,1 +1,3 @@
 https://ledgy.netlify.com/* https://ledgy.com/:splat 301!
+/*  /de/:splat  302  Language=de
+/*  /fr/:splat  302  Language=fr


### PR DESCRIPTION
Uses Netlify’s [language-based redirects](https://www.netlify.com/docs/redirects/#geoip-and-language-based-redirects) to send users to `/de` or `/fr`