### PR TITLE
enable headers on all pages

### DIFF
--- a/gatsby-config.js
+++ b/gatsby-config.js
@@ -76,19 +76,21 @@ module.exports = {
     {
       resolve: 'gatsby-plugin-netlify',
       options: {
-        allPageHeaders: [
-          [
-            "Content-Security-Policy: default-src 'self'",
-            "img-src 'self' data: https://csi.gstatic.com https://www.google-analytics.com https://maps.gstatic.com https://maps.googleapis.com https://stats.g.doubleclick.net https://dc.ads.linkedin.com/",
-            "object-src 'none'",
-            "font-src 'self' data: https://fonts.gstatic.com",
-            "script-src 'self' 'unsafe-inline' 'unsafe-eval' https://wchat.eu.freshchat.com/js/ https://snippets.freshchat.com/js/ https://www.googletagmanager.com/ https://www.google-analytics.com/ https://sjs.bizographics.com/ https://maps.googleapis.com/ https://www.linkedin.com/px/ https://px.ads.linkedin.com/",
-            "style-src 'self' 'unsafe-inline' https://fonts.googleapis.com/ https://wchat.eu.freshchat.com/css/ https://snippets.freshchat.com/css/ https://maps.googleapis.com/maps/api/",
-            "frame-src 'self' https://wchat.eu.freshchat.com/ https://ledgy.eu.webpush.freshchat.com/ https://www.youtube.com/"
-          ].join('; '),
-          'Referrer-Policy: strict-origin-when-cross-origin',
-          'Access-Control-Allow-Origin: *'
-        ]
+        headers: {
+          '/*': [
+            [
+              "Content-Security-Policy: default-src 'self'",
+              "img-src 'self' data: https://csi.gstatic.com https://www.google-analytics.com https://maps.gstatic.com https://maps.googleapis.com https://stats.g.doubleclick.net https://dc.ads.linkedin.com/",
+              "object-src 'none'",
+              "font-src 'self' data: https://fonts.gstatic.com",
+              "script-src 'self' 'unsafe-inline' 'unsafe-eval' https://wchat.eu.freshchat.com/js/ https://snippets.freshchat.com/js/ https://www.googletagmanager.com/ https://www.google-analytics.com/ https://sjs.bizographics.com/ https://maps.googleapis.com/ https://www.linkedin.com/px/ https://px.ads.linkedin.com/",
+              "style-src 'self' 'unsafe-inline' https://fonts.googleapis.com/ https://wchat.eu.freshchat.com/css/ https://snippets.freshchat.com/css/ https://maps.googleapis.com/maps/api/",
+              "frame-src 'self' https://wchat.eu.freshchat.com/ https://ledgy.eu.webpush.freshchat.com/ https://www.youtube.com/"
+            ].join('; '),
+            'Referrer-Policy: strict-origin-when-cross-origin',
+            'Access-Control-Allow-Origin: https://www.ledgy.com'
+          ]
+        }
       }
     },
     { resolve: 'gatsby-plugin-netlify-cache', options: { cachePublic: true } },

--- a/gatsby-config.js
+++ b/gatsby-config.js
@@ -86,7 +86,7 @@ module.exports = {
               "script-src 'self' 'unsafe-inline' 'unsafe-eval' https://wchat.eu.freshchat.com/js/ https://snippets.freshchat.com/js/ https://www.googletagmanager.com/ https://www.google-analytics.com/ https://sjs.bizographics.com/ https://maps.googleapis.com/ https://www.linkedin.com/px/ https://px.ads.linkedin.com/",
               "style-src 'self' 'unsafe-inline' https://fonts.googleapis.com/ https://wchat.eu.freshchat.com/css/ https://snippets.freshchat.com/css/ https://maps.googleapis.com/maps/api/",
               "frame-src 'self' https://wchat.eu.freshchat.com/ https://ledgy.eu.webpush.freshchat.com/ https://www.youtube.com/",
-              "connect-src 'self' https://maps.gstatic.com/"
+              "connect-src 'self' https://maps.gstatic.com/ https://snippets.freshchat.com/css/"
             ].join('; '),
             'Referrer-Policy: strict-origin-when-cross-origin',
             'Access-Control-Allow-Origin: https://www.ledgy.com'

--- a/gatsby-config.js
+++ b/gatsby-config.js
@@ -85,7 +85,8 @@ module.exports = {
               "font-src 'self' data: https://fonts.gstatic.com",
               "script-src 'self' 'unsafe-inline' 'unsafe-eval' https://wchat.eu.freshchat.com/js/ https://snippets.freshchat.com/js/ https://www.googletagmanager.com/ https://www.google-analytics.com/ https://sjs.bizographics.com/ https://maps.googleapis.com/ https://www.linkedin.com/px/ https://px.ads.linkedin.com/",
               "style-src 'self' 'unsafe-inline' https://fonts.googleapis.com/ https://wchat.eu.freshchat.com/css/ https://snippets.freshchat.com/css/ https://maps.googleapis.com/maps/api/",
-              "frame-src 'self' https://wchat.eu.freshchat.com/ https://ledgy.eu.webpush.freshchat.com/ https://www.youtube.com/"
+              "frame-src 'self' https://wchat.eu.freshchat.com/ https://ledgy.eu.webpush.freshchat.com/ https://www.youtube.com/",
+              "connect-src 'self' https://maps.gstatic.com/"
             ].join('; '),
             'Referrer-Policy: strict-origin-when-cross-origin',
             'Access-Control-Allow-Origin: https://www.ledgy.com'


### PR DESCRIPTION
Enable our custom headers on **all** pages. Previously, they were only attached to pages that are explicitly linked on our website, but missed some internal Gatsby files.

More documentation: https://github.com/gatsbyjs/gatsby/tree/master/packages/gatsby-plugin-netlify