### PR TITLE
Feature/lg 290/glossary page

### DIFF
--- a/src/components/Accordion.jsx
+++ b/src/components/Accordion.jsx
@@ -1,0 +1,32 @@
+// @flow
+
+import React, { type Node } from 'react';
+import { isBrowser } from '../layouts/utils';
+
+export const Accordion = (props: { children: Node }) => (
+  <div className="accordion my-4" {...props} />
+);
+
+export const AccordionItem = ({
+  id,
+  title,
+  children
+}: {|
+  id: string,
+  title: string,
+  children: Node
+|}) => {
+  const isOpen = isBrowser && window.top.location.hash === `#${id}`;
+  return (
+    <div className="card mb-0">
+      <h6 className="card-title mt-0 bg-white" id={id}>
+        <a className={!isOpen ? 'collapsed' : ''} data-toggle="collapse" href={`#${id}-body`}>
+          {title}
+        </a>
+      </h6>
+      <div id={`${id}-body`} className={`collapse ${isOpen ? 'show' : ''}`}>
+        <div className="card-body py-1">{children}</div>
+      </div>
+    </div>
+  );
+};

--- a/src/components/Accordion.jsx
+++ b/src/components/Accordion.jsx
@@ -16,7 +16,7 @@ export const AccordionItem = ({
   title: string,
   children: Node
 |}) => {
-  const isOpen = isBrowser && window.top.location.hash === `#${id}`;
+  const isOpen = isBrowser && window.top.location.hash === `#${id}-body`;
   return (
     <div className="card mb-0">
       <h6 className="card-title mt-0 bg-white" id={id}>

--- a/src/components/Content.jsx
+++ b/src/components/Content.jsx
@@ -19,7 +19,7 @@ export const ContentHeader = ({ heading }: {| heading: string |}) => (
   </header>
 );
 
-export const ContentBody = ({ children }: {| children: Array<Node> |}) => (
+export const ContentBody = ({ children }: {| children: Node | Array<Node> |}) => (
   <main className="main-content">
     <section className="section">
       <div className="container">{children}</div>

--- a/src/layouts/index.jsx
+++ b/src/layouts/index.jsx
@@ -147,8 +147,8 @@ const companyLinks = [
 ];
 const helpLinks = [
   [<Trans>Help Center</Trans>, 'help'],
-  [<Trans>Glossary</Trans>, 'glossary'],
   [<Trans>Getting Started</Trans>, 'help/getting-started'],
+  [<Trans>Glossary</Trans>, 'glossary'],
   [<Trans>ESOP Templates</Trans>, 'help/employee-participation-guide']
 ];
 const blogLinks = [

--- a/src/layouts/index.jsx
+++ b/src/layouts/index.jsx
@@ -146,7 +146,8 @@ const companyLinks = [
   [<Trans>Contact & Imprint</Trans>, 'contact']
 ];
 const helpLinks = [
-  [<Trans>Help</Trans>, 'help'],
+  [<Trans>Help Center</Trans>, 'help'],
+  [<Trans>Glossary</Trans>, 'glossary'],
   [<Trans>Getting Started</Trans>, 'help/getting-started'],
   [<Trans>ESOP Templates</Trans>, 'help/employee-participation-guide']
 ];

--- a/src/locale/de/messages.po
+++ b/src/locale/de/messages.po
@@ -6,7 +6,7 @@ msgstr ""
 "Content-Transfer-Encoding: 8bit\n"
 "Plural-Forms: nplurals=2; plural=(n != 1);\n"
 "POT-Creation-Date: 2018-09-12T18:40:54.619Z\n"
-"PO-Revision-Date: 2019-08-29 15:04+0200\n"
+"PO-Revision-Date: 2019-09-10 10:33+0200\n"
 "Language: de\n"
 "Report-Msgid-Bugs-To: \n"
 "Last-Translator: Timo Horstschäfer <timo@ledgy.com>\n"
@@ -358,7 +358,7 @@ msgstr "Tägliche Backups stellen sicher, dass nichts verloren gehen kann"
 
 #: src/pages/glossary.jsx:29
 msgid "Definitions for industry terms relating to cap tables, financing rounds, and legal topics for startups."
-msgstr ""
+msgstr "Definitionen von Fachbegriffen zu Cap Tables, Finanzierungsrunden und rechtlichen Themen für Startups."
 
 #: src/pages/about-us.jsx:170
 msgid "Digital entrepreneur and investor. Security, crypto & privacy expert"
@@ -642,7 +642,7 @@ msgstr "Erste Schritte"
 #: src/pages/glossary.jsx:31
 #: src/pages/help.jsx:33
 msgid "Glossary"
-msgstr ""
+msgstr "Glossar"
 
 #: src/pages/features/esop.jsx:80
 msgid "Grant options, phantom options, warrants or add inverse vesting to stock transactions"
@@ -1044,7 +1044,7 @@ msgstr "Belege deine Transaktionen mit den entsprechenden rechtlichen Dokumenten
 
 #: src/pages/help.jsx:34
 msgid "Quick explanations for investment lingo to get you started"
-msgstr ""
+msgstr "Kurze Erklärungen für den Fachjargon von Investitionen, um den Einstieg zu erleichtern"
 
 #: src/pages/features/collaboration.jsx:108
 msgid "Quickly pull up documents by the information of their linked transactions; for example, all of a specific stakeholder, share class or date range"

--- a/src/locale/de/messages.po
+++ b/src/locale/de/messages.po
@@ -199,7 +199,7 @@ msgstr "Blockchain-Notar"
 
 #: src/layouts/index.jsx:53
 #: src/layouts/index.jsx:141
-#: src/layouts/index.jsx:196
+#: src/layouts/index.jsx:197
 #: src/pages/blog.jsx:13
 #: src/pages/help.jsx:39
 msgid "Blog"
@@ -233,7 +233,7 @@ msgstr "Optionen für die Massenerfassung"
 msgid "Calculates waterfall analysis of liquidation preferences across all rounds"
 msgstr "Berechnet die Wasserfallanalyse der Liquidationspräferenzen über alle Runden hinweg"
 
-#: src/layouts/index.jsx:160
+#: src/layouts/index.jsx:161
 msgid "Cap Table"
 msgstr "Cap Table"
 
@@ -276,7 +276,7 @@ msgstr "Zusammenarbeit & Due Diligence"
 msgid "Coming soon"
 msgstr "Bald verfügbar"
 
-#: src/layouts/index.jsx:180
+#: src/layouts/index.jsx:181
 msgid "Company"
 msgstr "Unternehmen"
 
@@ -324,7 +324,7 @@ msgstr "Konvertiere das endgültige Szenario in Transaktionen mit nur zwei Klick
 msgid "Convert to transactions"
 msgstr "In Transaktionen umwandeln"
 
-#: src/layouts/index.jsx:155
+#: src/layouts/index.jsx:156
 msgid "Convertible Loans"
 msgstr "Convertible Loans"
 
@@ -332,7 +332,7 @@ msgstr "Convertible Loans"
 msgid "Convertibles"
 msgstr "Wandeldarlehen"
 
-#: src/layouts/index.jsx:170
+#: src/layouts/index.jsx:171
 msgid "Cookie Policy"
 msgstr "Cookie-Richtlinie"
 
@@ -356,6 +356,10 @@ msgstr "Erstelle Options- oder Phantompools, die für Mitarbeiter reserviert sin
 msgid "Daily backups ensure nothing is ever lost"
 msgstr "Tägliche Backups stellen sicher, dass nichts verloren gehen kann"
 
+#: src/pages/glossary.jsx:29
+msgid "Definitions for industry terms relating to cap tables, financing rounds, and legal topics for startups."
+msgstr ""
+
 #: src/pages/about-us.jsx:170
 msgid "Digital entrepreneur and investor. Security, crypto & privacy expert"
 msgstr "Digital Entrepreneur und Investor. Security-, Crypto- & Privacy-Experte"
@@ -368,10 +372,6 @@ msgstr "Verwässerter Cap Table"
 #: src/pages/pricing.jsx:174
 msgid "Discover all features"
 msgstr "Entdecke alle Features"
-
-#: src/pages/help.jsx:34
-msgid "Discover all our features and when to use them"
-msgstr "Entdecke alle unsere Funktionen und wie du sie nutzen kannst"
 
 #: src/components/Feature.jsx:91
 msgid "Discover more about Ledgy"
@@ -411,7 +411,7 @@ msgstr "Lade unsere ESOP-Templates herunter und verwende sie für dein Startup"
 msgid "Download holding confirmations with a single click"
 msgstr "Holdingbestätigungen mit einem einzigen Klick herunterladen"
 
-#: src/layouts/index.jsx:163
+#: src/layouts/index.jsx:164
 msgid "Due Diligence"
 msgstr "Due Diligence"
 
@@ -431,7 +431,7 @@ msgstr "Während seines Ingenieurstudiums als Stipendiat an der ETH Zürich, beg
 msgid "ESOP"
 msgstr "Mitarbeiterbeteiligung"
 
-#: src/layouts/index.jsx:151
+#: src/layouts/index.jsx:152
 msgid "ESOP Templates"
 msgstr "ESOP Templates"
 
@@ -451,7 +451,7 @@ msgstr "Elektronische Signaturen <0/>"
 msgid "Email notification about upcoming vesting event"
 msgstr "E-Mail-Benachrichtigung über bevorstehende Vesting-Ereignisse"
 
-#: src/layouts/index.jsx:162
+#: src/layouts/index.jsx:163
 msgid "Employee Incentives"
 msgstr "Mitarbeiter​​​​beteiligungen"
 
@@ -525,14 +525,13 @@ msgid "FAQ"
 msgstr "FAQ"
 
 #: src/layouts/index.jsx:50
-#: src/layouts/index.jsx:159
+#: src/layouts/index.jsx:160
 #: src/pages/features/captable.jsx:21
 #: src/pages/features/collaboration.jsx:21
 #: src/pages/features/esop.jsx:16
 #: src/pages/features/investors.jsx:21
 #: src/pages/features/modeling.jsx:21
 #: src/pages/features.jsx:14
-#: src/pages/help.jsx:33
 msgid "Features"
 msgstr "Funktionen"
 
@@ -590,7 +589,7 @@ msgstr "Für immer kostenlos mit 50 MB Speicherplatz"
 msgid "French"
 msgstr "Französisch"
 
-#: src/layouts/index.jsx:171
+#: src/layouts/index.jsx:172
 msgid "GDPR"
 msgstr "GDPR"
 
@@ -629,7 +628,7 @@ msgstr "Vermeide kostspielige Fehler"
 msgid "Get your cap table and employee participation plans right, from the beginning. Make your financing rounds a success and engage your investors and employees. Know your data is safe and compliant."
 msgstr "Erstelle deinen Cap Table und deine Mitarbeiterbeteiligungspläne von Anfang an richtig. Bringe deine Finanzierungsrunden zum Erfolg und motiviere deine Investoren und Mitarbeiter. Sei dir sicher, dass deine Daten gut aufgehoben sind."
 
-#: src/layouts/index.jsx:382
+#: src/layouts/index.jsx:383
 msgid "Get your cap table and employee participation plans right, from the beginning. Make your financing rounds a success and engage your investors and employees. Know your data is safe and compliant. Try now for free!"
 msgstr "Erstelle deinen Cap Table und Mitarbeiterbeteiligungspläne von Anfang an richtig. Bringe deine Finanzierungsrunden zum Erfolg und motiviere deine Investoren und Mitarbeiter. Sei unbesorgt, dass deine Daten sicher und konform sind. Jetzt kostenlos testen!"
 
@@ -637,6 +636,13 @@ msgstr "Erstelle deinen Cap Table und Mitarbeiterbeteiligungspläne von Anfang a
 #: src/pages/help.jsx:21
 msgid "Getting Started"
 msgstr "Erste Schritte"
+
+#: src/layouts/index.jsx:151
+#: src/pages/glossary.jsx:28
+#: src/pages/glossary.jsx:31
+#: src/pages/help.jsx:33
+msgid "Glossary"
+msgstr ""
 
 #: src/pages/features/esop.jsx:80
 msgid "Grant options, phantom options, warrants or add inverse vesting to stock transactions"
@@ -660,10 +666,10 @@ msgid "Healthcare & technology venture capital since 2001"
 msgstr "Healthcare & technology venture capital since 2001"
 
 #: src/layouts/index.jsx:52
-#: src/layouts/index.jsx:149
 msgid "Help"
 msgstr "Hilfe"
 
+#: src/layouts/index.jsx:149
 #: src/pages/help.jsx:64
 msgid "Help Center"
 msgstr "Help Center"
@@ -749,7 +755,7 @@ msgstr "Investoren-Portfolio"
 msgid "Investor relations and equity management for startups"
 msgstr "Investor Relations und Equity Management für Startups"
 
-#: src/layouts/index.jsx:164
+#: src/layouts/index.jsx:165
 msgid "Investors"
 msgstr "Investor Relations"
 
@@ -781,7 +787,7 @@ msgstr "KPI-Diagramm"
 msgid "KPIs"
 msgstr "KPIs"
 
-#: src/layouts/index.jsx:156
+#: src/layouts/index.jsx:157
 msgid "KPIs & Reports"
 msgstr "KPIs & Reports"
 
@@ -805,7 +811,7 @@ msgstr "Key performance indicators"
 msgid "Kpi chart"
 msgstr "KPI-Diagramm"
 
-#: src/layouts/index.jsx:263
+#: src/layouts/index.jsx:264
 msgid "Language"
 msgstr "Sprache"
 
@@ -837,7 +843,7 @@ msgstr "Ledgy macht es einfach, eine Investition mit einer pro-rata Verteilung z
 msgid "Ledgy scales with your needs. Free for startups, powerful for grown-ups."
 msgstr "Ledgy skaliert mit deinen Anforderungen. Kostenlos für Startups, leistungsstark für größere Firmen."
 
-#: src/layouts/index.jsx:214
+#: src/layouts/index.jsx:215
 msgid "Legal"
 msgstr "Legal"
 
@@ -893,7 +899,7 @@ msgstr "Marius hat sein Studium in Informatik an der Universität Mailand abgesc
 msgid "Meet the team behind Ledgy that went out to help startups thrive. Learn more about the people who trust in us."
 msgstr "Lerne das Team hinter Ledgy kennen, das sich zum Ziel gesetzt hat, Start-ups in ihrem Wachstum zu unterstützen. Erfahre mehr über die Menschen, die uns vertrauen."
 
-#: src/layouts/index.jsx:161
+#: src/layouts/index.jsx:162
 msgid "Modeling"
 msgstr "Modellierung"
 
@@ -905,7 +911,7 @@ msgstr "Mehrere Runden, 3 Szenarien"
 msgid "Name, email, address and any other details you provide. Provision of our services and management of your subscription. Providing you with updates about our services"
 msgstr "Name, E-Mail, Adresse und alle anderen Angaben, die du machst. Für die Bereitstellung unserer Dienstleistungen und Verwaltung deines Abonnements. Wir informieren dich über Neuigkeiten zu unseren Dienstleistungen"
 
-#: src/layouts/index.jsx:250
+#: src/layouts/index.jsx:251
 msgid "Newsletter"
 msgstr "Newsletter"
 
@@ -933,7 +939,7 @@ msgstr "Einer der aktivsten Schweizer Angel-Investoren für Early Stage"
 msgid "Oops. This email address is invalid."
 msgstr "Upsala. Diese E-Mail-Adresse ist leider ungültig."
 
-#: src/layouts/index.jsx:154
+#: src/layouts/index.jsx:155
 msgid "Option Pools"
 msgstr "Option Pools"
 
@@ -986,7 +992,7 @@ msgid "Portfolio history"
 msgstr "Portfolio-Historie"
 
 #: src/layouts/index.jsx:51
-#: src/layouts/index.jsx:165
+#: src/layouts/index.jsx:166
 #: src/pages/pricing.jsx:122
 #: src/pages/pricing.jsx:131
 msgid "Pricing"
@@ -1002,7 +1008,7 @@ msgstr "Prioritätssupport"
 msgid "Privacy"
 msgstr "Datenschutz"
 
-#: src/layouts/index.jsx:169
+#: src/layouts/index.jsx:170
 msgid "Privacy Policy"
 msgstr "Datenschutzrichtlinie"
 
@@ -1019,7 +1025,7 @@ msgstr "Datenschutz made in Europe. Weil deine Beteiligungsdaten nicht jeder ken
 msgid "Pro-rata distribution"
 msgstr "Pro-rata Verteilung"
 
-#: src/layouts/index.jsx:205
+#: src/layouts/index.jsx:206
 msgid "Product"
 msgstr "Produkt"
 
@@ -1035,6 +1041,10 @@ msgstr "Belege deine Transaktionen durch die jeweiligen rechtlichen Dokumente"
 #: src/pages/features/captable.jsx:138
 msgid "Prove your transactions with their respective legal documents"
 msgstr "Belege deine Transaktionen mit den entsprechenden rechtlichen Dokumenten"
+
+#: src/pages/help.jsx:34
+msgid "Quick explanations for investment lingo to get you started"
+msgstr ""
 
 #: src/pages/features/collaboration.jsx:108
 msgid "Quickly pull up documents by the information of their linked transactions; for example, all of a specific stakeholder, share class or date range"
@@ -1075,7 +1085,7 @@ msgstr "Bericht"
 msgid "Reporting"
 msgstr "Reporting"
 
-#: src/layouts/index.jsx:189
+#: src/layouts/index.jsx:190
 msgid "Resources"
 msgstr "Ressourcen"
 
@@ -1274,7 +1284,7 @@ msgstr "Technische Daten"
 msgid "Templates"
 msgstr "Templates"
 
-#: src/layouts/index.jsx:168
+#: src/layouts/index.jsx:169
 msgid "Terms of Service"
 msgstr "Nutzungsbedingungen"
 
@@ -1282,7 +1292,7 @@ msgstr "Nutzungsbedingungen"
 msgid "The Ledgy Blog"
 msgstr "Der Ledgy-Blog"
 
-#: src/layouts/index.jsx:381
+#: src/layouts/index.jsx:382
 #: src/pages/index.jsx:26
 msgid "The New Standard in Equity Management"
 msgstr "Der Neue Standard des Equity Management"
@@ -1547,7 +1557,7 @@ msgstr "und Aktiennummerierung wird nativ unterstützt"
 msgid "by liquidation preferences"
 msgstr "durch Liquidationspräferenzen"
 
-#: src/layouts/index.jsx:390
+#: src/layouts/index.jsx:391
 msgid "cap table, stock ledger, share register, startup, modeling, financing round, equity, esop, phantom, option plan, virtual, portfolio, reporting, investors"
 msgstr "Cap Table, Aktienbuch, Aktienregister, Startup, Modellierung, Finanzierungsrunde, Exit, ESOP, VSOP, Beteiligungsplan, Unternehmensbeteiligung, Mitarbeiterbeteiligung, Optionspläne, virtuelle Beteiligung, Reporting, Investor, Portfolio"
 

--- a/src/locale/en/messages.po
+++ b/src/locale/en/messages.po
@@ -200,7 +200,7 @@ msgstr "Blockchain notary"
 
 #: src/layouts/index.jsx:53
 #: src/layouts/index.jsx:141
-#: src/layouts/index.jsx:196
+#: src/layouts/index.jsx:197
 #: src/pages/blog.jsx:13
 #: src/pages/help.jsx:39
 msgid "Blog"
@@ -234,7 +234,7 @@ msgstr "Bulk entry options"
 msgid "Calculates waterfall analysis of liquidation preferences across all rounds"
 msgstr "Calculates waterfall analysis of liquidation preferences across all rounds"
 
-#: src/layouts/index.jsx:160
+#: src/layouts/index.jsx:161
 msgid "Cap Table"
 msgstr "Cap Table"
 
@@ -277,7 +277,7 @@ msgstr "Collaboration & Due Diligence"
 msgid "Coming soon"
 msgstr "Coming soon"
 
-#: src/layouts/index.jsx:180
+#: src/layouts/index.jsx:181
 msgid "Company"
 msgstr "Company"
 
@@ -325,7 +325,7 @@ msgstr "Convert the final scenario in just two clicks"
 msgid "Convert to transactions"
 msgstr "Convert to transactions"
 
-#: src/layouts/index.jsx:155
+#: src/layouts/index.jsx:156
 msgid "Convertible Loans"
 msgstr "Convertible Loans"
 
@@ -333,7 +333,7 @@ msgstr "Convertible Loans"
 msgid "Convertibles"
 msgstr "Convertibles"
 
-#: src/layouts/index.jsx:170
+#: src/layouts/index.jsx:171
 msgid "Cookie Policy"
 msgstr "Cookie Policy"
 
@@ -357,6 +357,10 @@ msgstr "Create option or phantom pools reserved for employees and keep track of 
 msgid "Daily backups ensure nothing is ever lost"
 msgstr "Daily backups ensure nothing is ever lost"
 
+#: src/pages/glossary.jsx:29
+msgid "Definitions for industry terms relating to cap tables, financing rounds, and legal topics for startups."
+msgstr "Definitions for industry terms relating to cap tables, financing rounds, and legal topics for startups."
+
 #: src/pages/about-us.jsx:170
 msgid "Digital entrepreneur and investor. Security, crypto & privacy expert"
 msgstr "Digital entrepreneur and investor. Security, crypto & privacy expert"
@@ -369,10 +373,6 @@ msgstr "Diluted cap table"
 #: src/pages/pricing.jsx:174
 msgid "Discover all features"
 msgstr "Discover all features"
-
-#: src/pages/help.jsx:34
-msgid "Discover all our features and when to use them"
-msgstr "Discover all our features and when to use them"
 
 #: src/components/Feature.jsx:91
 msgid "Discover more about Ledgy"
@@ -412,7 +412,7 @@ msgstr "Download and use our ESOP template"
 msgid "Download holding confirmations with a single click"
 msgstr "Download holding confirmations with a single click"
 
-#: src/layouts/index.jsx:163
+#: src/layouts/index.jsx:164
 msgid "Due Diligence"
 msgstr "Due Diligence"
 
@@ -432,7 +432,7 @@ msgstr "During his studies in engineering as an excellent scholar at ETH Zurich,
 msgid "ESOP"
 msgstr "ESOP"
 
-#: src/layouts/index.jsx:151
+#: src/layouts/index.jsx:152
 msgid "ESOP Templates"
 msgstr "ESOP Templates"
 
@@ -452,7 +452,7 @@ msgstr "Electronic signatures <0/>"
 msgid "Email notification about upcoming vesting event"
 msgstr "Email notification about upcoming vesting event"
 
-#: src/layouts/index.jsx:162
+#: src/layouts/index.jsx:163
 msgid "Employee Incentives"
 msgstr "Employee Incentives"
 
@@ -526,14 +526,13 @@ msgid "FAQ"
 msgstr "FAQ"
 
 #: src/layouts/index.jsx:50
-#: src/layouts/index.jsx:159
+#: src/layouts/index.jsx:160
 #: src/pages/features/captable.jsx:21
 #: src/pages/features/collaboration.jsx:21
 #: src/pages/features/esop.jsx:16
 #: src/pages/features/investors.jsx:21
 #: src/pages/features/modeling.jsx:21
 #: src/pages/features.jsx:14
-#: src/pages/help.jsx:33
 msgid "Features"
 msgstr "Features"
 
@@ -591,7 +590,7 @@ msgstr "Free forever with 50 MB storage"
 msgid "French"
 msgstr "French"
 
-#: src/layouts/index.jsx:171
+#: src/layouts/index.jsx:172
 msgid "GDPR"
 msgstr "GDPR"
 
@@ -630,7 +629,7 @@ msgstr "Get the calculations right"
 msgid "Get your cap table and employee participation plans right, from the beginning. Make your financing rounds a success and engage your investors and employees. Know your data is safe and compliant."
 msgstr "Get your cap table and employee participation plans right, from the beginning. Make your financing rounds a success and engage your investors and employees. Know your data is safe and compliant."
 
-#: src/layouts/index.jsx:382
+#: src/layouts/index.jsx:383
 msgid "Get your cap table and employee participation plans right, from the beginning. Make your financing rounds a success and engage your investors and employees. Know your data is safe and compliant. Try now for free!"
 msgstr "Get your cap table and employee participation plans right, from the beginning. Make your financing rounds a success and engage your investors and employees. Know your data is safe and compliant. Try now for free!"
 
@@ -638,6 +637,13 @@ msgstr "Get your cap table and employee participation plans right, from the begi
 #: src/pages/help.jsx:21
 msgid "Getting Started"
 msgstr "Getting Started"
+
+#: src/layouts/index.jsx:151
+#: src/pages/glossary.jsx:28
+#: src/pages/glossary.jsx:31
+#: src/pages/help.jsx:33
+msgid "Glossary"
+msgstr "Glossary"
 
 #: src/pages/features/esop.jsx:80
 msgid "Grant options, phantom options, warrants or add inverse vesting to stock transactions"
@@ -661,10 +667,10 @@ msgid "Healthcare & technology venture capital since 2001"
 msgstr "Healthcare & technology venture capital since 2001"
 
 #: src/layouts/index.jsx:52
-#: src/layouts/index.jsx:149
 msgid "Help"
 msgstr "Help"
 
+#: src/layouts/index.jsx:149
 #: src/pages/help.jsx:64
 msgid "Help Center"
 msgstr "Help Center"
@@ -750,7 +756,7 @@ msgstr "Investor portfolio"
 msgid "Investor relations and equity management for startups"
 msgstr "Investor relations and equity management for startups"
 
-#: src/layouts/index.jsx:164
+#: src/layouts/index.jsx:165
 msgid "Investors"
 msgstr "Investors"
 
@@ -782,7 +788,7 @@ msgstr "KPI chart"
 msgid "KPIs"
 msgstr "KPIs"
 
-#: src/layouts/index.jsx:156
+#: src/layouts/index.jsx:157
 msgid "KPIs & Reports"
 msgstr "KPIs & Reports"
 
@@ -806,7 +812,7 @@ msgstr "Key performance indicators"
 msgid "Kpi chart"
 msgstr "Kpi chart"
 
-#: src/layouts/index.jsx:263
+#: src/layouts/index.jsx:264
 msgid "Language"
 msgstr "Language"
 
@@ -838,7 +844,7 @@ msgstr "Ledgy makes it easy to simulate an investment with a pro-rata distributi
 msgid "Ledgy scales with your needs. Free for startups, powerful for grown-ups."
 msgstr "Ledgy scales with your needs. Free for startups, powerful for grown-ups."
 
-#: src/layouts/index.jsx:214
+#: src/layouts/index.jsx:215
 msgid "Legal"
 msgstr "Legal"
 
@@ -894,7 +900,7 @@ msgstr "Marius has a background in computer science, graduated from Milan Univer
 msgid "Meet the team behind Ledgy that went out to help startups thrive. Learn more about the people who trust in us."
 msgstr "Meet the team behind Ledgy that went out to help startups thrive. Learn more about the people who trust in us."
 
-#: src/layouts/index.jsx:161
+#: src/layouts/index.jsx:162
 msgid "Modeling"
 msgstr "Modeling"
 
@@ -906,7 +912,7 @@ msgstr "Multiple rounds, 3 scenarios"
 msgid "Name, email, address and any other details you provide. Provision of our services and management of your subscription. Providing you with updates about our services"
 msgstr "Name, email, address and any other details you provide. Provision of our services and management of your subscription. Providing you with updates about our services"
 
-#: src/layouts/index.jsx:250
+#: src/layouts/index.jsx:251
 msgid "Newsletter"
 msgstr "Newsletter"
 
@@ -934,7 +940,7 @@ msgstr "One of the most active Swiss early-stage angel investors"
 msgid "Oops. This email address is invalid."
 msgstr "Oops. This email address is invalid."
 
-#: src/layouts/index.jsx:154
+#: src/layouts/index.jsx:155
 msgid "Option Pools"
 msgstr "Option Pools"
 
@@ -987,7 +993,7 @@ msgid "Portfolio history"
 msgstr "Portfolio history"
 
 #: src/layouts/index.jsx:51
-#: src/layouts/index.jsx:165
+#: src/layouts/index.jsx:166
 #: src/pages/pricing.jsx:122
 #: src/pages/pricing.jsx:131
 msgid "Pricing"
@@ -1003,7 +1009,7 @@ msgstr "Priority support"
 msgid "Privacy"
 msgstr "Privacy"
 
-#: src/layouts/index.jsx:169
+#: src/layouts/index.jsx:170
 msgid "Privacy Policy"
 msgstr "Privacy Policy"
 
@@ -1020,7 +1026,7 @@ msgstr "Privacy made in Europe. Because your equity data is not for everyone."
 msgid "Pro-rata distribution"
 msgstr "Pro-rata distribution"
 
-#: src/layouts/index.jsx:205
+#: src/layouts/index.jsx:206
 msgid "Product"
 msgstr "Product"
 
@@ -1036,6 +1042,10 @@ msgstr "Prove your transactions by linking their respective legal documents"
 #: src/pages/features/captable.jsx:138
 msgid "Prove your transactions with their respective legal documents"
 msgstr "Prove your transactions with their respective legal documents"
+
+#: src/pages/help.jsx:34
+msgid "Quick explanations for investment lingo to get you started"
+msgstr "Quick explanations for investment lingo to get you started"
 
 #: src/pages/features/collaboration.jsx:108
 msgid "Quickly pull up documents by the information of their linked transactions; for example, all of a specific stakeholder, share class or date range"
@@ -1076,7 +1086,7 @@ msgstr "Report"
 msgid "Reporting"
 msgstr "Reporting"
 
-#: src/layouts/index.jsx:189
+#: src/layouts/index.jsx:190
 msgid "Resources"
 msgstr "Resources"
 
@@ -1275,7 +1285,7 @@ msgstr "Technical data"
 msgid "Templates"
 msgstr "Templates"
 
-#: src/layouts/index.jsx:168
+#: src/layouts/index.jsx:169
 msgid "Terms of Service"
 msgstr "Terms of Service"
 
@@ -1283,7 +1293,7 @@ msgstr "Terms of Service"
 msgid "The Ledgy Blog"
 msgstr "The Ledgy Blog"
 
-#: src/layouts/index.jsx:381
+#: src/layouts/index.jsx:382
 #: src/pages/index.jsx:26
 msgid "The New Standard in Equity Management"
 msgstr "The New Standard in Equity Management"
@@ -1548,7 +1558,7 @@ msgstr "and numbered shares are natively supported"
 msgid "by liquidation preferences"
 msgstr "by liquidation preferences"
 
-#: src/layouts/index.jsx:390
+#: src/layouts/index.jsx:391
 msgid "cap table, stock ledger, share register, startup, modeling, financing round, equity, esop, phantom, option plan, virtual, portfolio, reporting, investors"
 msgstr "cap table, stock ledger, share register, startup, modeling, financing round, equity, esop, phantom, option plan, virtual, portfolio, reporting, investors"
 

--- a/src/locale/fr/messages.po
+++ b/src/locale/fr/messages.po
@@ -200,7 +200,7 @@ msgstr "Notaire Blockchain"
 
 #: src/layouts/index.jsx:53
 #: src/layouts/index.jsx:141
-#: src/layouts/index.jsx:196
+#: src/layouts/index.jsx:197
 #: src/pages/blog.jsx:13
 #: src/pages/help.jsx:39
 msgid "Blog"
@@ -234,7 +234,7 @@ msgstr "Options d’entrée en bloc"
 msgid "Calculates waterfall analysis of liquidation preferences across all rounds"
 msgstr "Calcule l’analyse en cascade des préférences de liquidation à travers toutes les levées de fonds"
 
-#: src/layouts/index.jsx:160
+#: src/layouts/index.jsx:161
 msgid "Cap Table"
 msgstr "Cap Table"
 
@@ -277,7 +277,7 @@ msgstr "Collaboration et diligence raisonnable"
 msgid "Coming soon"
 msgstr "Prochainement"
 
-#: src/layouts/index.jsx:180
+#: src/layouts/index.jsx:181
 msgid "Company"
 msgstr "Société"
 
@@ -325,7 +325,7 @@ msgstr "Convertis le scénario final en seulement deux clics"
 msgid "Convert to transactions"
 msgstr "Convertir en transactions"
 
-#: src/layouts/index.jsx:155
+#: src/layouts/index.jsx:156
 msgid "Convertible Loans"
 msgstr "Billets convertibles"
 
@@ -333,7 +333,7 @@ msgstr "Billets convertibles"
 msgid "Convertibles"
 msgstr "Billets convertibles"
 
-#: src/layouts/index.jsx:170
+#: src/layouts/index.jsx:171
 msgid "Cookie Policy"
 msgstr "Politique de Cookies"
 
@@ -357,6 +357,10 @@ msgstr "Crée des pools d’options ou des pools virtuels réservés aux employ�
 msgid "Daily backups ensure nothing is ever lost"
 msgstr "Des sauvegardes quotidiennes garantissent que rien n’est jamais perdu"
 
+#: src/pages/glossary.jsx:29
+msgid "Definitions for industry terms relating to cap tables, financing rounds, and legal topics for startups."
+msgstr "Définitions pour termes relatifs aux cap tables, levées de fonds et questions juridiques pour startups."
+
 #: src/pages/about-us.jsx:170
 msgid "Digital entrepreneur and investor. Security, crypto & privacy expert"
 msgstr "Entrepreneur et investisseur en technologies digitales. Expert en sécurité et cryptographie"
@@ -369,10 +373,6 @@ msgstr "Cap table dilué"
 #: src/pages/pricing.jsx:174
 msgid "Discover all features"
 msgstr "Découvre les fonctionnalités"
-
-#: src/pages/help.jsx:34
-msgid "Discover all our features and when to use them"
-msgstr "Découvre toutes nos fonctionnalités et quand les utiliser"
 
 #: src/components/Feature.jsx:91
 msgid "Discover more about Ledgy"
@@ -412,7 +412,7 @@ msgstr "Télécharge et utilise notre modèle ESOP"
 msgid "Download holding confirmations with a single click"
 msgstr "Télécharge les confirmations de possession d’un simple clic"
 
-#: src/layouts/index.jsx:163
+#: src/layouts/index.jsx:164
 msgid "Due Diligence"
 msgstr "Diligence raisonnable"
 
@@ -432,7 +432,7 @@ msgstr "Pendant ses études d’ingénieur à l’ETH Zurich, Jules a commencé 
 msgid "ESOP"
 msgstr "ESOP"
 
-#: src/layouts/index.jsx:151
+#: src/layouts/index.jsx:152
 msgid "ESOP Templates"
 msgstr "ESOP Templates"
 
@@ -452,7 +452,7 @@ msgstr "Signatures électroniques <0/>"
 msgid "Email notification about upcoming vesting event"
 msgstr "Notification par e-mail d’évènement de complétion de vesting imminent"
 
-#: src/layouts/index.jsx:162
+#: src/layouts/index.jsx:163
 msgid "Employee Incentives"
 msgstr "Participation des employés"
 
@@ -526,14 +526,13 @@ msgid "FAQ"
 msgstr "FAQ"
 
 #: src/layouts/index.jsx:50
-#: src/layouts/index.jsx:159
+#: src/layouts/index.jsx:160
 #: src/pages/features/captable.jsx:21
 #: src/pages/features/collaboration.jsx:21
 #: src/pages/features/esop.jsx:16
 #: src/pages/features/investors.jsx:21
 #: src/pages/features/modeling.jsx:21
 #: src/pages/features.jsx:14
-#: src/pages/help.jsx:33
 msgid "Features"
 msgstr "Fonctionalités"
 
@@ -591,7 +590,7 @@ msgstr "Gratuit pour toujours avec 50 Mo de stockage"
 msgid "French"
 msgstr "Français"
 
-#: src/layouts/index.jsx:171
+#: src/layouts/index.jsx:172
 msgid "GDPR"
 msgstr "RGPD"
 
@@ -630,7 +629,7 @@ msgstr "Effectue les bons calculs"
 msgid "Get your cap table and employee participation plans right, from the beginning. Make your financing rounds a success and engage your investors and employees. Know your data is safe and compliant."
 msgstr "Bien comprendre ton cap table et tes plans d’actionnariat, dès le début. Fais de tes levées de fond un succès et mobilise tes investisseurs et tes employés. Sois sûr que tes données soient en sécurité."
 
-#: src/layouts/index.jsx:382
+#: src/layouts/index.jsx:383
 msgid "Get your cap table and employee participation plans right, from the beginning. Make your financing rounds a success and engage your investors and employees. Know your data is safe and compliant. Try now for free!"
 msgstr "Configure ton cap table et tes plans d’actionnariat des employés correctement, dès le début. Fais de tes levées de fonds un succès et mobilise tes investisseurs et tes employés. Aies la tranquillité d’esprit que tes données sont sûres et conformes. Essaye maintenant gratuitement !"
 
@@ -638,6 +637,13 @@ msgstr "Configure ton cap table et tes plans d’actionnariat des employés corr
 #: src/pages/help.jsx:21
 msgid "Getting Started"
 msgstr "Commencer"
+
+#: src/layouts/index.jsx:151
+#: src/pages/glossary.jsx:28
+#: src/pages/glossary.jsx:31
+#: src/pages/help.jsx:33
+msgid "Glossary"
+msgstr "Glossaire"
 
 #: src/pages/features/esop.jsx:80
 msgid "Grant options, phantom options, warrants or add inverse vesting to stock transactions"
@@ -661,10 +667,10 @@ msgid "Healthcare & technology venture capital since 2001"
 msgstr "Capital de risque dans le domaine de la santé et de la technologie depuis 2001"
 
 #: src/layouts/index.jsx:52
-#: src/layouts/index.jsx:149
 msgid "Help"
 msgstr "Aide"
 
+#: src/layouts/index.jsx:149
 #: src/pages/help.jsx:64
 msgid "Help Center"
 msgstr "Centre d’aide"
@@ -750,7 +756,7 @@ msgstr "Portefeuille d’investisseurs"
 msgid "Investor relations and equity management for startups"
 msgstr "Gestion d’actions et de relations aux investisseurs pour startups"
 
-#: src/layouts/index.jsx:164
+#: src/layouts/index.jsx:165
 msgid "Investors"
 msgstr "Investisseurs"
 
@@ -782,7 +788,7 @@ msgstr "Graphique des ICP"
 msgid "KPIs"
 msgstr "ICP"
 
-#: src/layouts/index.jsx:156
+#: src/layouts/index.jsx:157
 msgid "KPIs & Reports"
 msgstr "KPIs & Reports"
 
@@ -806,7 +812,7 @@ msgstr "Indicateurs clés de performance"
 msgid "Kpi chart"
 msgstr "Diagramme Kpi"
 
-#: src/layouts/index.jsx:263
+#: src/layouts/index.jsx:264
 msgid "Language"
 msgstr "Langue"
 
@@ -838,7 +844,7 @@ msgstr "Ledgy facilite la simulation d’un investissement avec une distribution
 msgid "Ledgy scales with your needs. Free for startups, powerful for grown-ups."
 msgstr "Ledgy s’adapte à tes besoins. Gratuit pour les startups, puissant pour les scale-ups."
 
-#: src/layouts/index.jsx:214
+#: src/layouts/index.jsx:215
 msgid "Legal"
 msgstr "Légal"
 
@@ -894,7 +900,7 @@ msgstr "Marius a une formation en informatique, est diplômé de l’Université
 msgid "Meet the team behind Ledgy that went out to help startups thrive. Learn more about the people who trust in us."
 msgstr "Rencontre l’équipe derrière Ledgy qui pour mission d’aider les startups à prospérer. En savoir plus sur les personnes qui nous font confiance."
 
-#: src/layouts/index.jsx:161
+#: src/layouts/index.jsx:162
 msgid "Modeling"
 msgstr "Modélisation"
 
@@ -906,7 +912,7 @@ msgstr "3 scénarios"
 msgid "Name, email, address and any other details you provide. Provision of our services and management of your subscription. Providing you with updates about our services"
 msgstr "Nom, adresse email, adresse et tout autre renseignement que tu nous fournis. Prestation de nos services et gestion de ton abonnement. Te fournir des mises à jour sur nos services"
 
-#: src/layouts/index.jsx:250
+#: src/layouts/index.jsx:251
 msgid "Newsletter"
 msgstr "Newsletter"
 
@@ -934,7 +940,7 @@ msgstr "L’un des angel investors suisses les plus actifs en early-stage"
 msgid "Oops. This email address is invalid."
 msgstr "Oups. Cette adresse e-mail n’est pas valide."
 
-#: src/layouts/index.jsx:154
+#: src/layouts/index.jsx:155
 msgid "Option Pools"
 msgstr "Option Pools"
 
@@ -987,7 +993,7 @@ msgid "Portfolio history"
 msgstr "Historique du portefeuille"
 
 #: src/layouts/index.jsx:51
-#: src/layouts/index.jsx:165
+#: src/layouts/index.jsx:166
 #: src/pages/pricing.jsx:122
 #: src/pages/pricing.jsx:131
 msgid "Pricing"
@@ -1003,7 +1009,7 @@ msgstr "Support prioritaire"
 msgid "Privacy"
 msgstr "Confidentialité"
 
-#: src/layouts/index.jsx:169
+#: src/layouts/index.jsx:170
 msgid "Privacy Policy"
 msgstr "Politique de confidentialité"
 
@@ -1020,7 +1026,7 @@ msgstr "Confidentialité made in Europe. Parce que tes données ne doivent pas �
 msgid "Pro-rata distribution"
 msgstr "Distribution au prorata"
 
-#: src/layouts/index.jsx:205
+#: src/layouts/index.jsx:206
 msgid "Product"
 msgstr "Produit"
 
@@ -1036,6 +1042,10 @@ msgstr "Prouve tes transactions en y reliant leurs documents légaux respectifs"
 #: src/pages/features/captable.jsx:138
 msgid "Prove your transactions with their respective legal documents"
 msgstr "Prouve tes transactions avec leurs documents légaux respectifs"
+
+#: src/pages/help.jsx:34
+msgid "Quick explanations for investment lingo to get you started"
+msgstr "Explications rapides et claires sur le jargon du domaine de l’investissement pour t’aider à démarrer"
 
 #: src/pages/features/collaboration.jsx:108
 msgid "Quickly pull up documents by the information of their linked transactions; for example, all of a specific stakeholder, share class or date range"
@@ -1076,7 +1086,7 @@ msgstr "Rapport"
 msgid "Reporting"
 msgstr "Rapport"
 
-#: src/layouts/index.jsx:189
+#: src/layouts/index.jsx:190
 msgid "Resources"
 msgstr "Ressources"
 
@@ -1275,7 +1285,7 @@ msgstr "Données Techniques"
 msgid "Templates"
 msgstr "Modèles"
 
-#: src/layouts/index.jsx:168
+#: src/layouts/index.jsx:169
 msgid "Terms of Service"
 msgstr "Conditions d’utilisation"
 
@@ -1283,7 +1293,7 @@ msgstr "Conditions d’utilisation"
 msgid "The Ledgy Blog"
 msgstr "Le Blog Ledgy"
 
-#: src/layouts/index.jsx:381
+#: src/layouts/index.jsx:382
 #: src/pages/index.jsx:26
 msgid "The New Standard in Equity Management"
 msgstr "Le nouveau standard en gestion d’actions"
@@ -1548,7 +1558,7 @@ msgstr "et les actions numérotées sont soutenues nativement"
 msgid "by liquidation preferences"
 msgstr "préférences de liquidation"
 
-#: src/layouts/index.jsx:390
+#: src/layouts/index.jsx:391
 msgid "cap table, stock ledger, share register, startup, modeling, financing round, equity, esop, phantom, option plan, virtual, portfolio, reporting, investors"
 msgstr "cap table, registre d’actions, startup, modélisation, ronde de financement, levée de fonds, actions, esop, plan d’options, virtuel, portefeuille, reporting, investisseurs, plan d’options"
 

--- a/src/pages/glossary.jsx
+++ b/src/pages/glossary.jsx
@@ -8,6 +8,7 @@ import { MDXProvider } from '@mdx-js/react';
 
 import { ContentHeader, ContentBody } from '../components/Content';
 import { Title } from '../layouts/utils';
+import { Accordion, AccordionItem } from '../components/Accordion';
 
 export default withI18n()(({ i18n, data }: Props) => {
   return (
@@ -21,18 +22,18 @@ export default withI18n()(({ i18n, data }: Props) => {
 
       <ContentBody>
         Hello, this is the Glossary!
-        {data.allContentfulGlossary.edges.map(edge => {
-          const { node } = edge;
-          const { title, description } = node;
-          return (
-            <span key={title}>
-              <h1>{title}</h1>
-              <MDXProvider>
-                <MDXRenderer>{description.childMdx.body}</MDXRenderer>
-              </MDXProvider>
-            </span>
-          );
-        })}
+        <Accordion>
+          {data.allContentfulGlossary.edges.map(edge => {
+            const { title, description } = edge.node;
+            return (
+              <AccordionItem id={title} key={title} title={title}>
+                <MDXProvider>
+                  <MDXRenderer>{description.childMdx.body}</MDXRenderer>
+                </MDXProvider>
+              </AccordionItem>
+            );
+          })}
+        </Accordion>
       </ContentBody>
     </div>
   );

--- a/src/pages/glossary.jsx
+++ b/src/pages/glossary.jsx
@@ -11,29 +11,26 @@ import { Title } from '../layouts/utils';
 import { Accordion, AccordionItem } from '../components/Accordion';
 
 export default withI18n()(({ i18n, data }: Props) => {
+  const accordionItems = data.allContentfulGlossary.edges.map(edge => {
+    const { slug, title, description } = edge.node;
+    return (
+      <AccordionItem id={slug} key={slug} title={title}>
+        <MDXProvider>
+          <MDXRenderer>{description.childMdx.body}</MDXRenderer>
+        </MDXProvider>
+      </AccordionItem>
+    );
+  });
+
   return (
     <div>
       <Title
         title={i18n.t`Glossary`}
         description={i18n.t`Definitions for industry terms relating to cap tables, financing rounds, and legal topics for startups.`}
       />
-
       <ContentHeader heading={i18n.t`Glossary`} />
-
       <ContentBody>
-        Hello, this is the Glossary!
-        <Accordion>
-          {data.allContentfulGlossary.edges.map(edge => {
-            const { title, description } = edge.node;
-            return (
-              <AccordionItem id={title} key={title} title={title}>
-                <MDXProvider>
-                  <MDXRenderer>{description.childMdx.body}</MDXRenderer>
-                </MDXProvider>
-              </AccordionItem>
-            );
-          })}
-        </Accordion>
+        <Accordion>{accordionItems}</Accordion>
       </ContentBody>
     </div>
   );
@@ -41,10 +38,10 @@ export default withI18n()(({ i18n, data }: Props) => {
 
 export const pageQuery = graphql`
   query {
-    allContentfulGlossary(sort: { order: DESC, fields: [title] }) {
+    allContentfulGlossary(sort: { order: ASC, fields: [title] }) {
       edges {
         node {
-          id
+          slug
           title
           description {
             childMdx {

--- a/src/pages/glossary.jsx
+++ b/src/pages/glossary.jsx
@@ -1,0 +1,57 @@
+// @flow
+
+import React from 'react';
+import { withI18n } from '@lingui/react';
+import { graphql } from 'gatsby';
+import { MDXRenderer } from 'gatsby-plugin-mdx';
+import { MDXProvider } from '@mdx-js/react';
+
+import { ContentHeader, ContentBody } from '../components/Content';
+import { Title } from '../layouts/utils';
+
+export default withI18n()(({ i18n, data }: Props) => {
+  return (
+    <div>
+      <Title
+        title={i18n.t`Glossary`}
+        description={i18n.t`Definitions for industry terms relating to cap tables, financing rounds, and legal topics for startups.`}
+      />
+
+      <ContentHeader heading={i18n.t`Glossary`} />
+
+      <ContentBody>
+        Hello, this is the Glossary!
+        {data.allContentfulGlossary.edges.map(edge => {
+          const { node } = edge;
+          const { title, description } = node;
+          return (
+            <span key={title}>
+              <h1>{title}</h1>
+              <MDXProvider>
+                <MDXRenderer>{description.childMdx.body}</MDXRenderer>
+              </MDXProvider>
+            </span>
+          );
+        })}
+      </ContentBody>
+    </div>
+  );
+});
+
+export const pageQuery = graphql`
+  query {
+    allContentfulGlossary(sort: { order: DESC, fields: [title] }) {
+      edges {
+        node {
+          id
+          title
+          description {
+            childMdx {
+              body
+            }
+          }
+        }
+      }
+    }
+  }
+`;

--- a/src/pages/help.jsx
+++ b/src/pages/help.jsx
@@ -8,10 +8,10 @@ import { FontAwesomeIcon } from '@fortawesome/react-fontawesome';
 import {
   faHiking,
   faQuestionCircle,
-  faCogs,
   faPencilRuler,
   faListAlt,
-  faVideo
+  faVideo,
+  faBook
 } from '@fortawesome/free-solid-svg-icons';
 
 import { Title, Hr, targetBlank } from '../layouts/utils';
@@ -30,10 +30,10 @@ const helpLinks = [
     faQuestionCircle
   ],
   [
-    <Trans>Features</Trans>,
-    <Trans>Discover all our features and when to use them</Trans>,
-    'features',
-    faCogs
+    <Trans>Glossary</Trans>,
+    <Trans>Quick explanations for investment lingo to get you started</Trans>,
+    'help/glossary',
+    faBook
   ],
   [
     <Trans>Blog</Trans>,

--- a/src/pages/help.jsx
+++ b/src/pages/help.jsx
@@ -32,7 +32,7 @@ const helpLinks = [
   [
     <Trans>Glossary</Trans>,
     <Trans>Quick explanations for investment lingo to get you started</Trans>,
-    'help/glossary',
+    'glossary',
     faBook
   ],
   [


### PR DESCRIPTION
Adds a glossary page that pulls glossary terms from Contentful

<img width="1440" alt="Screen Shot 2019-09-09 at 5 41 54 PM" src="https://user-images.githubusercontent.com/6724153/64545494-20dd3a80-d329-11e9-8f95-3ba1b122b93c.png">

- [x] French and German translations
- [x] Possible copyedit for "Quick explanations for investment lingo to get you started"