### PR TITLE
Fix/banner

### DIFF
--- a/src/components/Footer.jsx
+++ b/src/components/Footer.jsx
@@ -55,7 +55,7 @@ const helpLinks = [
   [<Trans>Help Center</Trans>, 'help'],
   [<Trans>Getting Started</Trans>, 'help/getting-started'],
   [<Trans>Glossary</Trans>, 'glossary'],
-  [<Trans>ESOP Templates</Trans>, 'help/employee-participation-guide'],
+  [<Trans>ESOP Templates</Trans>, 'employee-participation-plan-templates'],
   [<Trans>Round Calculator</Trans>, 'calculator']
 ];
 const blogLinks = [

--- a/src/components/PublicityBanner.jsx
+++ b/src/components/PublicityBanner.jsx
@@ -4,9 +4,13 @@ import React, { useState } from 'react';
 import { useStaticQuery, graphql } from 'gatsby';
 import { MDXRenderer } from 'gatsby-plugin-mdx';
 
-const Banner = ({ content, hide }: { content: Mdx, hide: () => void }) => (
-  <div className="publicity-banner position-fixed text-center bg-white border border-gray rounded p-4">
-    <MDXRenderer>{content.childMdx.body}</MDXRenderer>
+const Banner = ({ content, hide }: { content: ?Mdx, hide: () => void }) => (
+  <div
+    className={`publicity-banner position-fixed text-center bg-white border border-gray rounded p-4 ${
+      !content ? 'd-none' : ''
+    }`}
+  >
+    {!!content && <MDXRenderer>{content.childMdx.body}</MDXRenderer>}
     <button
       className="publicity-banner--button position-absolute bg-transparent border-0 p-2 p-lg-4 rounded-circle"
       onClick={hide}
@@ -21,7 +25,7 @@ const isVisibleNow = ({ node }: {| node: {| startAt: string, endAt: string |} |}
   return new Date(node.startAt).getTime() <= now && new Date(node.endAt).getTime() >= now;
 };
 
-export default () => {
+export default ({ pathname }: {| pathname: string |}) => {
   const [show, setShow] = useState(true);
   if (!show) return <div />;
 
@@ -45,8 +49,10 @@ export default () => {
       }
     `
   );
-  const banner = result.allContentfulBanner.edges.find(isVisibleNow);
-  if (!banner) return <div />;
 
-  return <Banner content={banner.node.content} hide={() => setShow(false)} />;
+  const banner = result.allContentfulBanner.edges.find(isVisibleNow);
+  const isPsopLaunchPage = pathname === '/employee-participation-plan-templates/';
+  const content = banner && !isPsopLaunchPage ? banner.node.content : null;
+
+  return <Banner content={content} hide={() => setShow(false)} />;
 };

--- a/src/layouts/index.jsx
+++ b/src/layouts/index.jsx
@@ -136,7 +136,7 @@ const TemplateWrapper = withI18n()(({ children, ...props }: SiteProps) => (
           </Helmet>
           <Nav {...props} prefix={prefix} />
           {isAppShell && <Loader />}
-          <PublicityBanner />
+          <PublicityBanner pathname={pathname} />
           {React.cloneElement((children: Object), { prefix, lang })}
           <Footer {...props} prefix={prefix} />
         </div>

--- a/src/layouts/style.scss
+++ b/src/layouts/style.scss
@@ -527,7 +527,7 @@ $markdown-spacer: $markdown-font-size;
   right: 0;
   color: $gray-700;
   @include media-breakpoint-up(lg) {
-    top: 50%;
+    top: 25%;
     transform: translate(0, -50%);
     right: 8px;
   }


### PR DESCRIPTION
* Hides the banner on our PSOP landing page
* Uses a `d-none` to not show the banner. Since not rendering the component at all always messes up our pre-rendered Gatsby page.