### PR TITLE
Use custom CTABanner for PSOP landing page

### DIFF
--- a/src/components/CTABanner.jsx
+++ b/src/components/CTABanner.jsx
@@ -1,30 +1,60 @@
 // @flow
 
-import React from 'react';
+import React, { type Node } from 'react';
 
 import sample from 'lodash/sample';
 import { Trans } from '@lingui/react';
-import { callToActionExperiments, trackSignup, isBrowser, appUrl } from '../layouts/utils';
+import {
+  callToActionExperiments,
+  trackSignup,
+  isBrowser,
+  appUrl,
+  targetBlank
+} from '../layouts/utils';
 
-export const CTABanner = () => {
-  const experiment = isBrowser ? sample(callToActionExperiments) : callToActionExperiments[0];
+const Banner = (props: { title: Node, url: string, trackingName: Node, CTAText: Node }) => {
+  const { title, url, trackingName, CTAText } = props;
   return (
     <section className="section bg-pale-secondary">
       <div className="container py-md-4">
         <div className="row m-0 w-100 justify-content-center align-items-center">
-          <h4 className="m-3 text-center">{experiment.title}</h4>
+          <h4 className="m-3 text-center">{title}</h4>
           <a
             className="cta-button m-3 btn btn-lg btn-round btn-primary align-self-center"
-            href={`${appUrl}/signup`}
+            {...targetBlank}
+            href={url}
             onClick={() => {
-              if (window.ga) window.ga('set', 'dimension2', experiment.name);
+              if (window.ga) window.ga('set', 'dimension2', { trackingName });
               trackSignup('clickSignup');
             }}
           >
-            <Trans>Get started</Trans>
+            {CTAText}
           </a>
         </div>
       </div>
     </section>
+  );
+};
+
+export const CTABanner = ({ location }: LayoutProps) => {
+  if (location.pathname === '/employee-participation-plan-templates/') {
+    return (
+      <Banner
+        title={<Trans>Free employee participation plan templates</Trans>}
+        url="https://app.ledgy.com/templates"
+        trackingName="clickPsopFooter"
+        CTAText={<Trans>Get now</Trans>}
+      />
+    );
+  }
+
+  const experiment = isBrowser ? sample(callToActionExperiments) : callToActionExperiments[0];
+  return (
+    <Banner
+      title={experiment.title}
+      url={`${appUrl}/signup`}
+      trackingName={experiment.name}
+      CTAText={<Trans>Get started</Trans>}
+    />
   );
 };

--- a/src/components/CTABanner.jsx
+++ b/src/components/CTABanner.jsx
@@ -37,7 +37,7 @@ const Banner = (props: { title: Node, url: string, trackingName: Node, CTAText: 
 };
 
 export const CTABanner = ({ location }: LayoutProps) => {
-  if (location.pathname === '/employee-participation-plan-templates/') {
+  if (location.pathname.includes('/employee-participation-plan-templates/')) {
     return (
       <Banner
         title={<Trans>Free employee participation plan templates</Trans>}

--- a/src/pages/employee-participation-plan-templates.jsx
+++ b/src/pages/employee-participation-plan-templates.jsx
@@ -32,7 +32,7 @@ const EquityPlans = ({ i18n, data }: Props) => {
   };
   const productHuntLaunchButton = (
     <ProductHuntButton
-      productHuntLink="https://www.producthunt.com/posts/startup-fundraising-calculator?utm_source=badge-featured&utm_medium=badge&utm_souce=badge-startup-fundraising-calculator"
+      productHuntLink="https://www.producthunt.com/posts/employee-participation-plan-templates?utm_source=badge-featured&utm_medium=badge&utm_souce=badge-startup-fundraising-calculator"
       trackSignupKey="clickProductHuntESOP"
       altText="Free Employee Participation Plan Templates - Using Ledgy! | Product Hunt Embed"
     />


### PR DESCRIPTION
**Description**
- Show a different CTA banner on the PSOP page 
- Update ProductHunt link on landing page

<img width="1440" alt="Screen Shot 2019-11-28 at 9 12 09 AM" src="https://user-images.githubusercontent.com/6724153/69788806-8a017b00-11bf-11ea-8594-977f235b69af.png">

<img width="1436" alt="Screen Shot 2019-11-28 at 9 12 32 AM" src="https://user-images.githubusercontent.com/6724153/69788810-8bcb3e80-11bf-11ea-9dc3-c54813513c22.png">
