### PR TITLE
Feature/add image link to testimonials

### DIFF
--- a/src/components/Testimonial.jsx
+++ b/src/components/Testimonial.jsx
@@ -2,12 +2,14 @@
 
 import React, { type Node } from 'react';
 import Img from 'gatsby-image';
+import { targetBlank } from '../layouts/utils';
 
 export const Testimonial = ({
   img,
   name,
   description,
   col,
+  url,
   rounded,
   minHeight = 80
 }: {
@@ -15,6 +17,7 @@ export const Testimonial = ({
   name: string,
   description: Node,
   col: number,
+  url?: string,
   rounded?: boolean,
   minHeight?: number
 }) => (
@@ -25,7 +28,9 @@ export const Testimonial = ({
       className="d-flex align-items-center justify-content-center mt-4"
       style={minHeight ? { minHeight } : {}}
     >
-      <Img {...img} alt={name} className={rounded ? 'avatar' : ''} />
+      <a {...targetBlank} href={url}>
+        <Img {...img} alt={name} className={rounded ? 'avatar' : ''} />
+      </a>
     </div>
     <div className="d-flex flex-column justify-content-between mt-4 h-100">
       <div className="testimonial-description">{description}</div>

--- a/src/components/templates/Testimonials.jsx
+++ b/src/components/templates/Testimonials.jsx
@@ -15,6 +15,7 @@ export const Testimonials = ({ data, i18n }: Object): Node => {
           people to work in a startup by profiting from its success.
         </Trans>
       ),
+      url: 'https://press.getyourguide.com/executive-team',
       img: data.johannesreck,
       rounded: true
     },
@@ -26,6 +27,7 @@ export const Testimonials = ({ data, i18n }: Object): Node => {
           this is already the norm, but in Germany, it’s still complicated.
         </Trans>
       ),
+      url: 'https://pitch.com/',
       img: data.christianreber,
       rounded: true
     },
@@ -37,6 +39,7 @@ export const Testimonials = ({ data, i18n }: Object): Node => {
           is paving the way to spread knowledge on how to involve employees in a startup’s success.
         </Trans>
       ),
+      url: 'https://deutschland.taylorwessing.com/en/home',
       img: data.taylorwessing,
       rounded: false
     },
@@ -49,16 +52,18 @@ export const Testimonials = ({ data, i18n }: Object): Node => {
           reward their talented employees.
         </Trans>
       ),
+      url: 'https://www.bakertilly.global/en/',
       img: data.bakertilly,
       rounded: false
     }
   ];
 
-  const testimonials = TESTIMONIALS.map(({ name, description, img, rounded }) => (
+  const testimonials = TESTIMONIALS.map(({ name, description, url, img, rounded }) => (
     <Testimonial
       col={5}
       key={name}
       name={name}
+      url={url}
       img={img}
       description={description}
       rounded={rounded}
@@ -73,6 +78,7 @@ export const Testimonials = ({ data, i18n }: Object): Node => {
           col={10}
           name={i18n.t`Dominic Jacquesson, VP Talent @ Index Ventures, a VC that founded the Not Optional initiative`}
           img={data.notoptional}
+          url="https://notoptional.eu/en/"
           minHeight={0}
           description={
             <Trans>

--- a/src/components/templates/Testimonials.jsx
+++ b/src/components/templates/Testimonials.jsx
@@ -76,7 +76,7 @@ export const Testimonials = ({ data, i18n }: Object): Node => {
       <div className="row text-center justify-content-center">
         <Testimonial
           col={10}
-          name={i18n.t`Dominic Jacquesson, VP Talent @ Index Ventures, a VC that founded the Not Optional initiative`}
+          name={i18n.t`Dominic Jacquesson, VP Talent @ Index Ventures, a VC who founded the Not Optional initiative`}
           img={data.notoptional}
           url="https://notoptional.eu/en/"
           minHeight={0}


### PR DESCRIPTION
Images have links now (see bottom right corner of screenshot).

And testimonials that don't pass in a `url` behave as though there was no link at all.

<img width="833" alt="Screen Shot 2019-11-28 at 11 22 47 AM" src="https://user-images.githubusercontent.com/6724153/69798412-8b3ba380-11d1-11ea-8d96-148baa707cef.png">
