### PR TITLE
Lg 895/render banner only on client

### DIFF
--- a/src/components/Markdown.jsx
+++ b/src/components/Markdown.jsx
@@ -97,4 +97,4 @@ export const LanguageHint = ({ lang, documentLang }: {| lang: string, documentLa
     </div>
   );
 
-export const Lead = ({ children }: {| children: Node |}) => <p className="lead">{children}</p>;
+export const Lead = ({ children }: {| children: Node |}) => <div className="lead">{children}</div>;


### PR DESCRIPTION
Rendering different output on the server depending on the time (via `isVisibleNow`) seems to mess up React. This approach always renders the `null` on the server and only creates the banner on the client (via `useEffect`)