### PR TITLE
Check page slug instead of id for caculator page

### DIFF
--- a/src/layouts/page.jsx
+++ b/src/layouts/page.jsx
@@ -8,7 +8,7 @@ import { LongText } from '../components/LongText';
 import { DefaultHeader, CalculatorHeader } from '../components/Header';
 import { Title } from '../layouts/utils';
 
-const CALCULATOR_ID = 'cfcd898c-876a-55cd-befe-3918b0753a5c';
+const CALCULATOR_SLUG = 'calculator';
 
 export default ({
   data,
@@ -18,9 +18,10 @@ export default ({
   ...Props,
   data: {| contentfulPage: Page, site: { siteMetadata: { siteUrl: string } } |}
 |}) => {
-  const { id, title, description, language, content, author, date, cover } = data.contentfulPage;
+  const { slug, title, description, language, content, author, date, cover } = data.contentfulPage;
   const { siteUrl } = data.site.siteMetadata;
-  const showCalculatorHeader = id === CALCULATOR_ID;
+  const showCalculatorHeader = slug === CALCULATOR_SLUG;
+
   return (
     <div>
       <Title


### PR DESCRIPTION
- It seems as though the `id` of a page can change over time (possibly related to routing, moving, etc.) At some point, the id we hardcoded for the calculator page ceased to match the page's actual id.
- I have instead changed the logic to check if the slug matches, which should be a more permanent (or at least more debuggable) way to identify the calculator page.

<img width="1437" alt="Screen Shot 2020-02-10 at 4 06 58 PM" src="https://user-images.githubusercontent.com/6724153/74161677-9f633e80-4c1f-11ea-95dd-242ee59cf125.png">

